### PR TITLE
fix create-vault task and subgraph abi dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,7 @@ crashlytics-build.properties
 fabric.properties
 
 # NodeJS dependencies
-node_modules/*
+node_modules/
 
 # ES-Lint
 .eslintcache

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ yarn
 yarn test
 ```
 
+## Deploy Local
+1. `yarn hardhat node` -- this spins up a local hardhat network, it is useful to note down the accounts
+2. `yarn hardhat compile`
+3. `yarn hardhat deploy --noverify --network localhost`
+4. `git clone https://github.com/graphprotocol/graph-node/`
+5. `cd graph-node/docker`
+6. If on Linux, `./setup.sh && docker-compose up`, otherwise `docker-compose up`
+7. `cd subgraph`, update the addresses in `subgraph.yaml` with the addresses from step 3 (or from `sdk/deployment/localhost/factories-latest.json`)
+8. `yarn && yarn codegen && yarn create-local && yarn deploy-local`
+
 ## Contribute
 
 To report bugs within this package, create an issue in this repository.

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -37,6 +37,8 @@ dataSources:
       abis:
         - name: InstanceRegistry
           file: ./abis/IInstanceRegistry.json
+        - name: VaultContract
+          file: ./abis/IUniversalVault.json
       eventHandlers:
         - event: InstanceAdded(address)
           handler: handleNewVault

--- a/subgraph/yarn.lock
+++ b/subgraph/yarn.lock
@@ -239,9 +239,9 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
-"assemblyscript@git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3":
+"assemblyscript@https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3":
   version "0.6.0"
-  resolved "git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3"
+  resolved "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
   dependencies:
     "@protobufjs/utf8" "^1.1.0"
     binaryen "77.0.0-nightly.20190407"


### PR DESCRIPTION
## Description

1. Fixed bug in `create-vault` task
2. Fixed the `subgraph.yaml` file: `VaultFactory` data source needs `VaultContract` in its abis
3. Added flag to bypass etherscan verification when deploying smart contracts locally
4. Added documentation for local deployment

## Testing

Ran the steps under the added `Deploy Local` section in the README. Verified that the subgraph and smart contracts are deployed locally.

Ran `yarn hardhat create-vault --network localhost` to test that the `create-vault` task effectively creates a vautl.