### PR TITLE
fix withdraw and unstake actions

### DIFF
--- a/frontend/src/sdk/actions.ts
+++ b/frontend/src/sdk/actions.ts
@@ -101,7 +101,7 @@ export const unstake = async (
     amount,
   )
 
-  return geyser.unstake(vault.address, amount, permission) as Promise<
+  return geyser.unstakeAndClaim(vault.address, amount, permission) as Promise<
     TransactionResponse
   >
 }

--- a/frontend/src/sdk/actions.ts
+++ b/frontend/src/sdk/actions.ts
@@ -118,13 +118,11 @@ export const withdraw = async (
   const vault = new Contract(vaultAddress, config.VaultTemplate.abi, signer)
   const token = new Contract(tokenAddress, ERC20_ABI, signer)
 
-  const calldata = (
-    await token.populateTransaction.transfer(recipientAddress, amount)
-  ).data
-
-  return vault.externalCall([token.address, 0, calldata]) as Promise<
-    TransactionResponse
-  >
+  return vault.transferERC20(
+    token.address,
+    recipientAddress,
+    amount,
+  ) as Promise<TransactionResponse>
 }
 
 /// Combined Actions ///

--- a/frontend/src/sdk/deployments/localhost/factories-latest.json
+++ b/frontend/src/sdk/deployments/localhost/factories-latest.json
@@ -29,11 +29,11 @@
       "event Locked(address delegate, address token, uint256 amount)",
       "event RageQuit(address delegate, address token, bool notified, string reason)",
       "event Unlocked(address delegate, address token, uint256 amount)",
+      "function LOCK_TYPEHASH() view returns (bytes32)",
       "function RAGEQUIT_GAS() view returns (uint256)",
+      "function UNLOCK_TYPEHASH() view returns (bytes32)",
       "function calculateLockID(address delegate, address token) pure returns (bytes32 lockID)",
       "function checkBalances() view returns (bool validity)",
-      "function externalCall(tuple(address to, uint256 value, bytes data) call) payable returns (bytes returnData)",
-      "function externalCallMulti(tuple(address to, uint256 value, bytes data)[] calls) payable returns (bytes[] returnData)",
       "function getBalanceDelegated(address token, address delegate) view returns (uint256 balance)",
       "function getBalanceLocked(address token) view returns (uint256 balance)",
       "function getLockAt(uint256 index) view returns (tuple(address delegate, address token, uint256 balance) lockData)",
@@ -47,6 +47,8 @@
       "function nft() view returns (address nftAddress)",
       "function owner() view returns (address ownerAddress)",
       "function rageQuit(address delegate, address token) returns (bool notified, string error)",
+      "function transferERC20(address token, address to, uint256 amount)",
+      "function transferETH(address to, uint256 amount) payable",
       "function unlock(address token, uint256 amount, bytes permission)"
     ]
   },
@@ -59,6 +61,7 @@
       "event InstanceAdded(address instance)",
       "event InstanceRemoved(address instance)",
       "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)",
+      "function addressToUint(address vault) pure returns (uint256 tokenId)",
       "function approve(address to, uint256 tokenId)",
       "function balanceOf(address owner) view returns (uint256)",
       "function baseURI() view returns (string)",
@@ -74,6 +77,7 @@
       "function isInstance(address instance) view returns (bool validity)",
       "function name() view returns (string)",
       "function ownerOf(uint256 tokenId) view returns (address)",
+      "function predictCreate2Address(bytes32 salt) view returns (address instance)",
       "function safeTransferFrom(address from, address to, uint256 tokenId)",
       "function safeTransferFrom(address from, address to, uint256 tokenId, bytes _data)",
       "function setApprovalForAll(address operator, bool approved)",
@@ -83,7 +87,8 @@
       "function tokenOfOwnerByIndex(address owner, uint256 index) view returns (uint256)",
       "function tokenURI(uint256 tokenId) view returns (string)",
       "function totalSupply() view returns (uint256)",
-      "function transferFrom(address from, address to, uint256 tokenId)"
+      "function transferFrom(address from, address to, uint256 tokenId)",
+      "function uint256ToAddress(uint256 tokenId) pure returns (address vault)"
     ]
   },
   "GeyserRegistry": {
@@ -107,15 +112,16 @@
       "event GeyserCreated(address rewardPool, address powerSwitch)",
       "event GeyserFunded(uint256 amount, uint256 duration)",
       "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
-      "event RewardClaimed(address vault, address recipient, address token, uint256 amount)",
+      "event RewardClaimed(address vault, address token, uint256 amount)",
       "event Staked(address vault, uint256 amount)",
       "event Unstaked(address vault, uint256 amount)",
       "event VaultFactoryRegistered(address factory)",
       "event VaultFactoryRemoved(address factory)",
       "function BASE_SHARES_PER_WEI() view returns (uint256)",
+      "function MAX_REWARD_TOKENS() view returns (uint256)",
       "function MAX_STAKES_PER_VAULT() view returns (uint256)",
       "function calculateReward(uint256 unlockedRewards, uint256 stakeAmount, uint256 stakeDuration, uint256 totalStakeUnits, tuple(uint256 floor, uint256 ceiling, uint256 time) rewardScaling) pure returns (uint256 reward)",
-      "function calculateRewardFromStakes(tuple(uint256 amount, uint256 timestamp)[] stakes, uint256 unstakeAmount, uint256 unlockedRewards, uint256 totalStakeUnits, uint256 timestamp, tuple(uint256 floor, uint256 ceiling, uint256 time) rewardScaling) pure returns (tuple(uint256 amount, uint256 timestamp)[] newStakes, uint256 reward, uint256 newTotalStakeUnits)",
+      "function calculateRewardFromStakes(tuple(uint256 amount, uint256 timestamp)[] stakes, uint256 unstakeAmount, uint256 unlockedRewards, uint256 totalStakeUnits, uint256 timestamp, tuple(uint256 floor, uint256 ceiling, uint256 time) rewardScaling) pure returns (tuple(uint256 lastStakeAmount, uint256 newStakesCount, uint256 reward, uint256 newTotalStakeUnits) out)",
       "function calculateStakeUnits(uint256 amount, uint256 start, uint256 end) pure returns (uint256 stakeUnits)",
       "function calculateTotalStakeUnits(tuple(uint256 amount, uint256 timestamp)[] stakes, uint256 timestamp) pure returns (uint256 totalStakeUnits)",
       "function calculateUnlockedRewards(tuple(uint256 duration, uint256 start, uint256 shares)[] rewardSchedules, uint256 rewardBalance, uint256 sharesOutstanding, uint256 timestamp) pure returns (uint256 unlockedRewards)",
@@ -138,7 +144,7 @@
       "function getVaultData(address vault) view returns (tuple(uint256 totalStake, tuple(uint256 amount, uint256 timestamp)[] stakes) vaultData)",
       "function getVaultFactoryAtIndex(uint256 index) view returns (address factory)",
       "function getVaultFactorySetLength() view returns (uint256 length)",
-      "function initialize(address owner, address rewardPoolFactory, address powerSwitchFactory, address stakingToken, address rewardToken, tuple(uint256 floor, uint256 ceiling, uint256 time) rewardScaling)",
+      "function initialize(address ownerAddress, address rewardPoolFactory, address powerSwitchFactory, address stakingToken, address rewardToken, tuple(uint256 floor, uint256 ceiling, uint256 time) rewardScaling)",
       "function initializeLock()",
       "function isOffline() view returns (bool status)",
       "function isOnline() view returns (bool status)",
@@ -154,19 +160,17 @@
       "function rescueTokensFromRewardPool(address token, address recipient, uint256 amount)",
       "function stake(address vault, uint256 amount, bytes permission)",
       "function transferOwnership(address newOwner)",
-      "function unstakeAndClaim(address vault, address recipient, uint256 amount, bytes permission)"
+      "function unstakeAndClaim(address vault, uint256 amount, bytes permission)"
     ]
   },
   "RouterV1": {
     "address": "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707",
     "abi": [
-      "function create2Vault(address vaultFactory, bytes32 salt) returns (address vault)",
       "function create2VaultAndStake(address geyser, address vaultFactory, address vaultOwner, uint256 amount, bytes32 salt, bytes permission) returns (address vault)",
       "function create2VaultPermitAndStake(address geyser, address vaultFactory, address vaultOwner, bytes32 salt, tuple(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) permit, bytes permission) returns (address vault)",
-      "function createVault(address vaultFactory) returns (address vault)",
       "function permitAndStake(address geyser, address vault, tuple(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) permit, bytes permission)",
       "function stakeMulti(tuple(address geyser, address vault, uint256 amount, bytes permission)[] requests)",
-      "function unstakeMulti(tuple(address geyser, address vault, address recipient, uint256 amount, bytes permission)[] requests)"
+      "function unstakeMulti(tuple(address geyser, address vault, uint256 amount, bytes permission)[] requests)"
     ]
   }
 }

--- a/subgraph/abis/IGeyser.json
+++ b/subgraph/abis/IGeyser.json
@@ -896,11 +896,6 @@
           "type": "address"
         },
         {
-          "internalType": "address",
-          "name": "recipient",
-          "type": "address"
-        },
-        {
           "internalType": "uint256",
           "name": "amount",
           "type": "uint256"


### PR DESCRIPTION
## Description

### Withdraw changes
`externalCall` was replaced by `transferERC20` in https://github.com/ampleforth/token-geyser-v2/pull/193/files#diff-b838c6f4829d8bf6ca7077cf3c754797746c5ae697d7c6ccd19952a6b9887ccaR893-R895

### Unstake changes
`unstake` should be `unstakeAndClaim`

## Testing

Added some `MockERC20` to an account in local network, created a vault, deposited some `MockERC20` to the vault, and withdrew some of it from the vault. Also staked the vault, and unstaked. Made sure transactions were successful, and that the balances were correct