### PR TITLE
fix subgraph and create geyser task

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn test
 ## Deploy Local
 1. `yarn hardhat node` -- this spins up a local hardhat network, it is useful to note down the accounts
 2. `yarn hardhat compile`
-3. `yarn hardhat deploy --noverify --network localhost`
+3. `yarn hardhat deploy --mock --no-verify --network localhost`
 4. `git clone https://github.com/graphprotocol/graph-node/`
 5. `cd graph-node/docker`
 6. If on Linux, `./setup.sh && docker-compose up`, otherwise `docker-compose up`

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -8,7 +8,7 @@ type Geyser @entity {
   id: ID! # ${geyser.address}
   powerSwitch: Bytes!
   rewardPool: Bytes!
-  rewardPoolBalances: [RewardPoolBalance]!
+  rewardPoolBalances: [RewardPoolBalance]! @derivedFrom(field: "geyser")
   unlockedReward: BigInt!
   stakingToken: Bytes!
   rewardToken: Bytes!

--- a/subgraph/src/geyser.ts
+++ b/subgraph/src/geyser.ts
@@ -99,7 +99,6 @@ export function handleGeyserCreated(event: GeyserCreated): void {
   entity.scalingTime = geyserData.rewardScaling.time
   entity.status = 'Online'
   entity.bonusTokens = []
-  entity.rewardPoolBalances = []
 
   _updateGeyser(entity, geyserContract, event.block.timestamp)
 }

--- a/subgraph/src/geyser.ts
+++ b/subgraph/src/geyser.ts
@@ -54,10 +54,13 @@ function updateRewardPoolBalance(
   entity.save()
 }
 
-function updateGeyser(geyserAddress: Address, timestamp: BigInt): void {
-  let geyser = new Geyser(geyserAddress.toHex())
-  let geyserContract = GeyserContract.bind(geyserAddress)
+function _updateGeyser(
+  geyser: Geyser,
+  geyserContract: GeyserContract,
+  timestamp: BigInt,
+): void {
   let geyserData = geyserContract.getGeyserData()
+  let geyserAddress = Address.fromHexString(geyser.id) as Address
 
   geyser.totalStake = geyserData.totalStake
   geyser.totalStakeUnits = geyserContract.getCurrentTotalStakeUnits()
@@ -73,13 +76,19 @@ function updateGeyser(geyserAddress: Address, timestamp: BigInt): void {
   geyser.save()
 }
 
+function updateGeyser(geyserAddress: Address, timestamp: BigInt): void {
+  let geyser = new Geyser(geyserAddress.toHex())
+  let geyserContract = GeyserContract.bind(geyserAddress)
+  _updateGeyser(geyser, geyserContract, timestamp)
+}
+
 export function handleGeyserCreated(event: GeyserCreated): void {
   let entity = new Geyser(event.address.toHex())
-  let geyser = GeyserContract.bind(event.address)
+  let geyserContract = GeyserContract.bind(event.address)
 
   PowerSwitchTemplate.create(event.params.powerSwitch)
 
-  let geyserData = geyser.getGeyserData()
+  let geyserData = geyserContract.getGeyserData()
 
   entity.powerSwitch = event.params.powerSwitch
   entity.rewardPool = event.params.rewardPool
@@ -89,10 +98,10 @@ export function handleGeyserCreated(event: GeyserCreated): void {
   entity.scalingCeiling = geyserData.rewardScaling.ceiling
   entity.scalingTime = geyserData.rewardScaling.time
   entity.status = 'Online'
+  entity.bonusTokens = []
+  entity.rewardPoolBalances = []
 
-  updateGeyser(event.address, event.block.timestamp)
-
-  entity.save()
+  _updateGeyser(entity, geyserContract, event.block.timestamp)
 }
 
 export function handleGeyserFunded(event: GeyserFunded): void {


### PR DESCRIPTION
## Description

Existing event handler for geyser creation in the subgraph and `create-geyser` hardhat task were broken.

### `create-geyser` task changes:
Deployment and initialization of a geyser must happen at separate steps.

Due to the way the subgraph and contracts work, creating a geyser requires a very specific order. Particularly, for a `Geyser` entity to be indexed in the subgraph, the event `GeyserCreated` *must* be emitted *after* the geyser has been registered to the `GeyserRegistry`, because [a new data source will not process historical events](https://thegraph.com/docs/define-a-subgraph#instantiating-a-data-source-template) . However, a geyser must be deployed in order to be registered to the registry.

Since `Geyser` is an upgradeable contract, we can execute the following in order:
- Deploy the geyser contract + proxy, without calling the initializer
- Register the geyser to the registry
- Initialize the geyser, which will then emit `GeyserCreated`

Then, the geyser will be indexed in the subgraph as required.

### Subgraph changes:
When a geyser entity is first created, its non-derived array fields need to be set to empty arrays initially.
Additionally, objects in `rewardPoolBalances` should be derived

## Testing

- Started local network with `yarn hardhat node` and `yarn hardhat deploy --network localhost --no-verify --mock`
- Started local graph-node with `docker-compose up` (under graph-node/docker) and `yarn create-local && yarn deploy-local` (under subgraph/)
- Ran the task 
```
yarn hardhat create-geyser \
--staking-token {address of MockERC20} \
--reward-token {address of MockAmpl} \
--floor 10 \
--ceiling 20 \
--time 100 \
--network localhost
```
- Queried `http://localhost:8000/subgraphs/name/thegostep/ampleforth-geyser-v2` to make sure that the geyser was indexed