### PR TITLE
use router contract for create/deposit/stake

### DIFF
--- a/contracts/RouterV1.sol
+++ b/contracts/RouterV1.sol
@@ -4,6 +4,7 @@ pragma abicoder v2;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import {IERC20Permit} from "@openzeppelin/contracts/drafts/IERC20Permit.sol";
 import {TransferHelper} from "@uniswap/lib/contracts/libraries/TransferHelper.sol";
 
@@ -14,7 +15,31 @@ import {IFactory} from "./Factory/IFactory.sol";
 /// @title RouterV1
 /// @notice Convenience contract for ampleforth geyser
 /// @dev Security contact: dev-support@ampleforth.org
-contract RouterV1 {
+contract RouterV1 is IERC721Receiver {
+    function onERC721Received(
+        address,
+        address,
+        uint256,
+        bytes calldata
+    ) external pure override returns (bytes4) {
+        return IERC721Receiver.onERC721Received.selector;
+    }
+
+    function create2Vault(address vaultFactory, bytes32 salt) public returns (address vault) {
+        vault = IFactory(vaultFactory).create2("", salt);
+    }
+
+    function depositStake(
+        address geyser,
+        address vault,
+        uint256 amount,
+        bytes calldata permission
+    ) public {
+        address stakingToken = IGeyser(geyser).getGeyserData().stakingToken;
+        TransferHelper.safeTransferFrom(stakingToken, msg.sender, vault, amount);
+        IGeyser(geyser).stake(vault, amount, permission);
+    }
+
     function create2VaultAndStake(
         address geyser,
         address vaultFactory,
@@ -24,15 +49,11 @@ contract RouterV1 {
         bytes calldata permission
     ) external returns (address vault) {
         // create vault
-        vault = IFactory(vaultFactory).create2("", salt);
-        // get staking token
-        address stakingToken = IGeyser(geyser).getGeyserData().stakingToken;
+        vault = create2Vault(vaultFactory, salt);
         // transfer ownership
         IERC721(vaultFactory).safeTransferFrom(address(this), vaultOwner, uint256(vault));
-        // transfer tokens
-        TransferHelper.safeTransferFrom(stakingToken, msg.sender, vault, amount);
-        // stake
-        IGeyser(geyser).stake(vault, amount, permission);
+        // transfer tokens and stake
+        depositStake(geyser, vault, amount, permission);
     }
 
     struct Permit {

--- a/frontend/src/components/GeyserStakeView.tsx
+++ b/frontend/src/components/GeyserStakeView.tsx
@@ -1,0 +1,42 @@
+import { Wallet } from 'ethers';
+import React, { useContext, useState } from 'react';
+import { MOCK_ERC_20_ADDRESS } from '../constants';
+import { GeyserContext } from '../context/GeyserContext';
+import { VaultContext } from '../context/VaultContext';
+import Web3Context from '../context/Web3Context';
+import { approveCreateDepositStake, approveDepositStake, parseUnitsWithDecimals, permitDepositStake } from '../sdk';
+import { Input } from '../styling/styles';
+
+interface GeyserStakeViewProps {}
+
+export const GeyserStakeView: React.FC<GeyserStakeViewProps> = () => {
+  const [amount, setAmount] = useState<string>('')
+  const { selectedGeyser } = useContext(GeyserContext)
+  const { signer } = useContext(Web3Context)
+  const { selectedVault } = useContext(VaultContext)
+
+  const handleStake = async () => {
+    if (selectedGeyser) {
+      const parsedAmount = await parseUnitsWithDecimals(amount, MOCK_ERC_20_ADDRESS, signer!)
+      const geyserAddress = selectedGeyser.id
+      if (selectedVault) {
+        const vaultAddress = selectedVault.id
+        await approveDepositStake(geyserAddress, vaultAddress, parsedAmount, signer as Wallet)
+      } else {
+        await approveCreateDepositStake(geyserAddress, parsedAmount, signer as Wallet)
+      }
+    }
+  }
+
+  return (
+    <div>
+      <Input
+        type="number"
+        placeholder="Enter amount"
+        value={amount}
+        onChange={(e) => setAmount(e.currentTarget.value)}
+      />
+      <button onClick={handleStake}> Stake </button>
+    </div>
+  );
+}

--- a/frontend/src/context/GeyserContext.tsx
+++ b/frontend/src/context/GeyserContext.tsx
@@ -4,11 +4,22 @@ import { LoadingSpinner } from '../components/LoadingSpinner'
 import { GET_GEYSERS } from '../queries/geyser'
 import { Geyser } from '../types'
 
-export const GeyserContext = createContext<{ geysers: Geyser[] }>({ geysers: [] })
+export const GeyserContext = createContext<{
+  geysers: Geyser[],
+  selectedGeyser: Geyser | null,
+  selectGeyser: (geyser: Geyser) => void, 
+}>({
+  geysers: [],
+  selectedGeyser: null,
+  selectGeyser: () => {}
+})
 
 export const GeyserContextProvider: React.FC = ({ children }) => {
   const { loading: geyserLoading, data: geyserData } = useQuery(GET_GEYSERS)
   const [geysers, setGeysers] = useState<Geyser[]>([])
+  const [selectedGeyser, setSelectedGeyser] = useState<Geyser | null>(null)
+
+  const selectGeyser = (geyser: Geyser) => setSelectedGeyser(geyser)
 
   useEffect(() => {
     if (geyserData && geyserData.geysers) setGeysers(geyserData.geysers as Geyser[])
@@ -16,5 +27,5 @@ export const GeyserContextProvider: React.FC = ({ children }) => {
 
   if (geyserLoading) return <LoadingSpinner />
 
-  return <GeyserContext.Provider value={{ geysers }}>{children}</GeyserContext.Provider>
+  return <GeyserContext.Provider value={{ geysers, selectedGeyser, selectGeyser }}>{children}</GeyserContext.Provider>
 }

--- a/frontend/src/queries/geyser.ts
+++ b/frontend/src/queries/geyser.ts
@@ -5,6 +5,14 @@ export const GET_GEYSERS = gql`
     geysers(first: 1000) {
       id
       rewardToken
+      stakingToken
+      totalStake
+      totalStakeUnits
+      status
+      scalingFloor
+      scalingCeiling
+      scalingTime
+      unlockedReward
     }
   }
 `

--- a/frontend/src/sdk/abis.ts
+++ b/frontend/src/sdk/abis.ts
@@ -182,4 +182,18 @@ export const ERC20_ABI = [
     stateMutability: 'nonpayable',
     type: 'function',
   },
+  {
+    inputs: [],
+    name: 'decimals',
+    outputs: [
+      {
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    payable: false,
+    stateMutability: 'pure',
+    type: 'function',
+  },
 ]

--- a/frontend/src/sdk/actions.ts
+++ b/frontend/src/sdk/actions.ts
@@ -123,7 +123,7 @@ export const approveCreateDepositStake = async (geyserAddress: string, amount: B
   return router.create2VaultAndStake(...args) as Promise<TransactionResponse>
 }
 
-export const depositStake = async (
+export const approveDepositStake = async (
   geyserAddress: string,
   vaultAddress: string,
   amount: BigNumberish,

--- a/frontend/src/sdk/deployments/localhost/factories-latest.json
+++ b/frontend/src/sdk/deployments/localhost/factories-latest.json
@@ -166,8 +166,11 @@
   "RouterV1": {
     "address": "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707",
     "abi": [
+      "function create2Vault(address vaultFactory, bytes32 salt) returns (address vault)",
       "function create2VaultAndStake(address geyser, address vaultFactory, address vaultOwner, uint256 amount, bytes32 salt, bytes permission) returns (address vault)",
       "function create2VaultPermitAndStake(address geyser, address vaultFactory, address vaultOwner, bytes32 salt, tuple(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) permit, bytes permission) returns (address vault)",
+      "function depositStake(address geyser, address vault, uint256 amount, bytes permission)",
+      "function onERC721Received(address, address, uint256, bytes) pure returns (bytes4)",
       "function permitAndStake(address geyser, address vault, tuple(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) permit, bytes permission)",
       "function stakeMulti(tuple(address geyser, address vault, uint256 amount, bytes permission)[] requests)",
       "function unstakeMulti(tuple(address geyser, address vault, uint256 amount, bytes permission)[] requests)"

--- a/frontend/src/sdk/utils.ts
+++ b/frontend/src/sdk/utils.ts
@@ -1,14 +1,18 @@
 import { TypedDataField } from '@ethersproject/abstract-signer'
 import { BigNumberish, Contract, Signer, Wallet } from 'ethers'
-import { splitSignature } from 'ethers/lib/utils'
+import { parseUnits, splitSignature } from 'ethers/lib/utils'
 import mainnetConfig from './deployments/mainnet/factories-latest.json'
 import goerliConfig from './deployments/goerli/factories-latest.json'
 import localhostConfig from './deployments/localhost/factories-latest.json'
 import { ERC20_ABI } from './abis'
 
-export const ERC20Decimals = async (tokenAddress: string) => {
-  const token = new Contract(tokenAddress, ERC20_ABI)
+export const ERC20Decimals = async (tokenAddress: string, signer: Signer) => {
+  const token = new Contract(tokenAddress, ERC20_ABI, signer)
   return token.decimals()
+}
+
+export const parseUnitsWithDecimals = async (value: string, tokenAddress: string, signer: Signer) => {
+  return parseUnits(value, await ERC20Decimals(tokenAddress, signer))
 }
 
 export const loadNetworkConfig = async (signer: Signer) => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -14,10 +14,15 @@ export type Vault = {
   locks: Lock[]
 }
 
-type GeyserStatus = 'Online' | 'Offline' | 'Shutdown'
+export enum GeyserStatus {
+  ONLINE = 'Online',
+  OFFLINE = 'Offline',
+  SHUTDOWN = 'Shutdown'
+}
 
 export type Geyser = {
   id: string
+  rewardToken: string
   stakingToken: string
   totalStake: string
   totalStakeUnits: string

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -10,13 +10,22 @@ type ClaimedReward = {
 export type Vault = {
   id: string
   nonce: string
-  // TODO: proper typing for reward
   claimedReward: ClaimedReward[]
   locks: Lock[]
 }
 
+type GeyserStatus = 'Online' | 'Offline' | 'Shutdown'
+
 export type Geyser = {
   id: string
+  stakingToken: string
+  totalStake: string
+  totalStakeUnits: string
+  status: GeyserStatus
+  scalingFloor: string
+  scalingCeiling: string
+  scalingTime: string
+  unlockedReward: string
 }
 
 export type Lock = {

--- a/subgraph/src/geyser.ts
+++ b/subgraph/src/geyser.ts
@@ -128,6 +128,7 @@ function updateVaultStake(geyserAddress: Address, vaultAddress: Address, timesta
   lock.stakeUnits = geyserContract.getCurrentVaultStakeUnits(vaultAddress)
   lock.amount = geyserContract.getVaultData(vaultAddress).totalStake
   lock.lastUpdate = timestamp
+  lock.token = geyserContract.getGeyserData().stakingToken
 
   updateGeyser(geyserAddress, timestamp)
 


### PR DESCRIPTION
## Description

- Fixed `approveCreateDepositStake` function in sdk
- Fixed RouterV1 contract to inherit from IERC721Receiver to make it able to mint vault
- Added `create2Vault` and `depositStake` functions to RouterV1 contract. The former is referenced in the sdk, but not implemented in the contract, the latter is added to make it possible to combine deposit & stake into a single action
- Fixed `updateVaultStake` in subgraph: the token of the lock is a required field
- Added `decimals()` to ERC20_ABI
- Added a React component that includes number input + button to create/deposit/stake in one action