### PR TITLE
stats context to provide user and geyser stats

### DIFF
--- a/contracts/Mock/MockERC20.sol
+++ b/contracts/Mock/MockERC20.sol
@@ -8,3 +8,9 @@ contract MockERC20 is ERC20 {
         ERC20._mint(recipient, amount);
     }
 }
+
+contract MockBAL is ERC20 {
+    constructor(address recipient, uint256 amount) ERC20("MockBAL", "BAL") {
+        ERC20._mint(recipient, amount);
+    }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@types/react-dom": "^17.0.0",
     "@types/styled-components": "^5.1.9",
     "bnc-onboard": "^1.25.0",
+    "coingecko-api": "^1.0.10",
     "graphql": "^15.5.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -56,6 +57,7 @@
     ]
   },
   "devDependencies": {
+    "@types/coingecko-api": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "^4.26.0",
     "@typescript-eslint/parser": "^4.26.0",
     "autoprefixer": "^9.8.6",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { GeyserContextProvider } from './context/GeyserContext'
 import { Web3Provider } from './context/Web3Context'
 import { client } from './queries/client'
 import { WalletContextProvider } from './context/WalletContext'
+import { StatsContextProvider } from './context/StatsContext'
 
 function App() {
   return (
@@ -14,8 +15,10 @@ function App() {
         <GeyserContextProvider>
           <VaultContextProvider>
             <WalletContextProvider>
-              <Header />
-              <GeyserFirstContainer />
+              <StatsContextProvider>
+                <Header />
+                <GeyserFirstContainer />
+              </StatsContextProvider>
             </WalletContextProvider>
           </VaultContextProvider>
         </GeyserContextProvider>

--- a/frontend/src/components/GeyserFirstContainer.tsx
+++ b/frontend/src/components/GeyserFirstContainer.tsx
@@ -10,7 +10,7 @@ interface Props {}
 
 export const GeyserFirstContainer: React.FC<Props> = () => {
   const [view, setView] = useState<GeyserView>(GeyserView.STAKE)
-  const getToggleOptions = () => Object.values(GeyserView).map((view) => view.toString())
+  const getToggleOptions = () => Object.values(GeyserView).map((v) => v.toString())
   const selectView = (option: string) => setView(option as GeyserView)
 
   return (

--- a/frontend/src/components/GeyserStakeView.tsx
+++ b/frontend/src/components/GeyserStakeView.tsx
@@ -18,7 +18,8 @@ export const GeyserStakeView: React.FC<Props> = () => {
   const [amount, setAmount] = useState<string>('')
   const [parsedAmount, setParsedAmount] = useState<BigNumber>(BigNumber.from('0'))
   const [receipt, setReceipt] = useState<TransactionReceipt>()
-  const { selectedGeyser, stakingTokenDecimals, stakingTokenSymbol } = useContext(GeyserContext)
+  const { selectedGeyser, stakingTokenInfo } = useContext(GeyserContext)
+  const { decimals: stakingTokenDecimals, symbol: stakingTokenSymbol } = stakingTokenInfo
   const { signer } = useContext(Web3Context)
   const { selectedVault, currentLock } = useContext(VaultContext)
   const { walletAmount, refreshWalletAmount } = useContext(WalletContext)

--- a/frontend/src/components/GeyserStakeView.tsx
+++ b/frontend/src/components/GeyserStakeView.tsx
@@ -50,7 +50,7 @@ export const GeyserStakeView: React.FC<Props> = () => {
     }
   }
 
-  const formatDisplayAmount = (amount: BigNumberish) => formatAmount(amount, stakingTokenDecimals, stakingTokenSymbol)
+  const formatDisplayAmount = (amt: BigNumberish) => formatAmount(amt, stakingTokenDecimals, stakingTokenSymbol)
 
   const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setAmount(e.currentTarget.value)

--- a/frontend/src/components/GeyserUnstakeView.tsx
+++ b/frontend/src/components/GeyserUnstakeView.tsx
@@ -46,7 +46,7 @@ export const GeyserUnstakeView: React.FC<Props> = () => {
     }
   }
 
-  const formatDisplayAmount = (amount: BigNumberish) => formatAmount(amount, stakingTokenDecimals, stakingTokenSymbol)
+  const formatDisplayAmount = (amt: BigNumberish) => formatAmount(amt, stakingTokenDecimals, stakingTokenSymbol)
 
   const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setAmount(e.currentTarget.value)

--- a/frontend/src/components/GeyserUnstakeView.tsx
+++ b/frontend/src/components/GeyserUnstakeView.tsx
@@ -1,7 +1,7 @@
 import { BigNumber, BigNumberish, Wallet } from 'ethers'
 import { parseUnits } from 'ethers/lib/utils'
 import React, { useContext, useEffect, useState } from 'react'
-import { TransactionReceipt } from '@ethersproject/providers'
+import { TransactionReceipt, TransactionResponse } from '@ethersproject/providers'
 import { GeyserContext } from '../context/GeyserContext'
 import { VaultContext } from '../context/VaultContext'
 import { WalletContext } from '../context/WalletContext'
@@ -27,22 +27,23 @@ export const GeyserUnstakeView: React.FC<Props> = () => {
 
   const userStake = BigNumber.from(amountOrZero(currentLock?.amount))
 
-  useEffect(() => {
-    refresh()
-  }, [receipt])
-
   const refresh = () => {
     setAmount('')
     setParsedAmount(BigNumber.from('0'))
     refreshWalletAmount()
   }
 
+  useEffect(() => {
+    refresh()
+  }, [receipt])
+
   const handleUnstake = async () => {
     if (selectedGeyser && selectedVault && signer) {
       const geyserAddress = selectedGeyser.id
       const vaultAddress = selectedVault.id
-      const tx = await unstakeWithdraw(geyserAddress, vaultAddress, parsedAmount, signer as Wallet)
-      setReceipt(await tx.wait())
+      const txs: [TransactionResponse, TransactionResponse] = await unstakeWithdraw(geyserAddress, vaultAddress, parsedAmount, signer as Wallet)
+      const [withdrawStakingTokenTx] = txs
+      setReceipt(await withdrawStakingTokenTx.wait())
     }
   }
 

--- a/frontend/src/components/GeyserUnstakeView.tsx
+++ b/frontend/src/components/GeyserUnstakeView.tsx
@@ -19,7 +19,8 @@ export const GeyserUnstakeView: React.FC<Props> = () => {
   const [amount, setAmount] = useState<string>('')
   const [receipt, setReceipt] = useState<TransactionReceipt>()
   const [parsedAmount, setParsedAmount] = useState<BigNumber>(BigNumber.from('0'))
-  const { selectedGeyser, stakingTokenDecimals, stakingTokenSymbol } = useContext(GeyserContext)
+  const { selectedGeyser, stakingTokenInfo } = useContext(GeyserContext)
+  const { decimals: stakingTokenDecimals, symbol: stakingTokenSymbol } = stakingTokenInfo
   const { signer } = useContext(Web3Context)
   const { selectedVault, currentLock } = useContext(VaultContext)
   const { walletAmount, refreshWalletAmount } = useContext(WalletContext)

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react'
 import styled from 'styled-components/macro'
+import { toChecksumAddress } from 'web3-utils'
 import { GeyserContext } from '../context/GeyserContext'
 import { VaultContext } from '../context/VaultContext'
 import { displayAddr } from '../utils/formatDisplayAddress'
@@ -8,8 +9,16 @@ import { HeaderWalletButton } from './HeaderWalletButton'
 interface Props {}
 
 export const Header: React.FC<Props> = () => {
-  const { geysers } = useContext(GeyserContext)
-  const { vaults } = useContext(VaultContext)
+  const { geysers, selectGeyserById, geyserAddressToName } = useContext(GeyserContext)
+  const { vaults, selectVaultById } = useContext(VaultContext)
+
+  const handleSelectGeyser = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    selectGeyserById(e.currentTarget.value)
+  }
+
+  const handleSelectVault = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    selectVaultById(e.currentTarget.value)
+  }
 
   return (
     <Container className="flex flex-wrap">
@@ -17,11 +26,11 @@ export const Header: React.FC<Props> = () => {
         <LogoDiv className="float-left">Λ</LogoDiv>
         <div className="float-left">
           Geyser:
-          <Select>
+          <Select onChange={handleSelectGeyser}>
             {geysers.map((geyser) => (
               <option key={geyser.id} value={geyser.id}>
                 {' '}
-                {displayAddr(geyser.id)}{' '}
+                {geyserAddressToName.get(toChecksumAddress(geyser.id))}{' '}
               </option>
             ))}
           </Select>
@@ -29,7 +38,7 @@ export const Header: React.FC<Props> = () => {
         {vaults && vaults.length > 0 && (
           <div className="float-left">
             Vault:
-            <Select>
+            <Select onChange={handleSelectVault}>
               {vaults.map((vault) => (
                 <option key={vault.id} value={vault.id}>
                   {' '}
@@ -47,8 +56,15 @@ export const Header: React.FC<Props> = () => {
   )
 }
 
-const Select: React.FC = ({ children }) => {
-  return <DropDownSelect className="rounded-2xl">{children}</DropDownSelect>
+interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+const Select: React.FC<SelectProps> = (props) => {
+  const { children } = props
+  return (
+    <DropDownSelect {...props} className="rounded-2xl">
+      {children}
+    </DropDownSelect>
+  )
 }
 
 const Container = styled.div`

--- a/frontend/src/components/PositiveInput.tsx
+++ b/frontend/src/components/PositiveInput.tsx
@@ -8,8 +8,13 @@ interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
 export const PositiveInput: React.FC<Props> = (props) => {
   const { onChange, precision } = props
 
-  const respectsPrecision = (value: string) =>
-    precision !== undefined ? value.split('.')[1].length <= precision : true
+  const respectsPrecision = (value: string) => {
+    if (precision !== undefined) {
+      const parts = value.split('.')
+      return parts.length > 0 ? parts[1].length <= precision : true
+    }
+    return true
+  }
 
   const positiveOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const pattern = new RegExp(`(^\\d+$|^\\d+\\.\\d+$|^\\d+\\.$|^$)`)

--- a/frontend/src/config/geyser.ts
+++ b/frontend/src/config/geyser.ts
@@ -1,33 +1,55 @@
 import { StakingToken } from '../constants'
+import { GeyserConfig } from '../types'
 
-export type GeyserConfig = {
-  name: string
-  address: string
-  stakingToken: StakingToken
-  platformTokenAddress?: string
-  platformTokenClaimLink?: string
-}
-
-export const geysersConfig: GeyserConfig[] = [
+const mockGeyserConfigs: GeyserConfig[] = [
   {
     name: 'Trinity V1 (Balancer BTC-ETH-AMPL)',
     address: '0x0dcd1bf9a1b36ce34237eeafef220932846bcd82',
     stakingToken: StakingToken.MOCK,
-    // platformTokenAddress: '0x0000000000000000000000000000000000000000',
-    // platformTokenClaimLink: 'https://claim.balancer.fi/#/',
-  },
-  {
-    name: 'Trinity V2 (Balancer BTC-ETH-AMPL)',
-    address: '0x4a679253410272dd5232b3ff7cf5dbb88f295319',
-    stakingToken: StakingToken.MOCK,
-    // platformTokenAddress: '0x0000000000000000000000000000000000000000',
-    // platformTokenClaimLink: 'https://claim.balancer.fi/#/',
-  },
-  {
-    name: 'Trinity V3 (Balancer BTC-ETH-AMPL)',
-    address: '0x59b670e9fa9d0a427751af201d676719a970857b',
-    stakingToken: StakingToken.MOCK,
-    // platformTokenAddress: '0x0000000000000000000000000000000000000000',
-    // platformTokenClaimLink: 'https://claim.balancer.fi/#/',
+    platformTokenConfigs: [],
   },
 ]
+
+const mainnetGeyserConfigs: GeyserConfig[] = [
+  {
+    name: 'Pescadero V1 (Sushiswap ETH-AMPL)',
+    address: '0x0000000000000000000000000000000000000000',
+    stakingToken: StakingToken.SUSHISWAP,
+    platformTokenConfigs: [],
+    // staking token / pool address: 0xCb2286d9471cc185281c4f763d34A962ED212962
+  },
+  {
+    name: 'Beehive V3 (Uniswap ETH-AMPL)',
+    address: '0x0000000000000000000000000000000000000000',
+    stakingToken: StakingToken.UNISWAP_V2,
+    platformTokenConfigs: [],
+    // staking token / pool address: 0xc5be99A02C6857f9Eac67BbCE58DF5572498F40c
+  },
+  {
+    name: 'Trinity V1 (Balancer BTC-ETH-AMPL)',
+    address: '0x0000000000000000000000000000000000000000',
+    stakingToken: StakingToken.BALANCER_V1,
+    platformTokenConfigs: [
+      {
+        address: '0xba100000625a3754423978a60c9317c58a424e3d',
+        claimLink: 'https://claim.balancer.fi/#/',
+      },
+    ],
+    // staking token / pool address: 0xa751A143f8fe0a108800Bfb915585E4255C2FE80
+  },
+  {
+    name: 'Old Faithful V1 (Balancer AMPL-USDC)',
+    address: '0x0000000000000000000000000000000000000000',
+    stakingToken: StakingToken.BALANCER_SMART_POOL_V1,
+    platformTokenConfigs: [
+      {
+        address: '0xba100000625a3754423978a60c9317c58a424e3d',
+        claimLink: 'https://claim.balancer.fi/#/',
+      },
+    ],
+  },
+  // staking token / pool address: 0x49F2befF98cE62999792Ec98D0eE4Ad790E7786F
+]
+
+export const geyserConfigs: GeyserConfig[] =
+  process.env.NODE_ENV === 'development' ? mockGeyserConfigs : mainnetGeyserConfigs

--- a/frontend/src/config/geyser.ts
+++ b/frontend/src/config/geyser.ts
@@ -1,0 +1,29 @@
+import { StakingToken } from './stakingToken'
+
+export type GeyserConfig = {
+  name: string
+  address: string
+  stakingToken: StakingToken
+  platformTokenAddress?: string
+}
+
+export const geysersConfig: GeyserConfig[] = [
+  {
+    name: 'Trinity V1 (Balancer BTC-ETH-AMPL)',
+    address: '0x0dcd1bf9a1b36ce34237eeafef220932846bcd82',
+    stakingToken: StakingToken.MOCK,
+    platformTokenAddress: '0x0000000000000000000000000000000000000000',
+  },
+  {
+    name: 'Trinity V2 (Balancer BTC-ETH-AMPL)',
+    address: '0x4a679253410272dd5232b3ff7cf5dbb88f295319',
+    stakingToken: StakingToken.MOCK,
+    platformTokenAddress: '0x0000000000000000000000000000000000000000',
+  },
+  {
+    name: 'Trinity V3 (Balancer BTC-ETH-AMPL)',
+    address: '0x59b670e9fa9d0a427751af201d676719a970857b',
+    stakingToken: StakingToken.MOCK,
+    platformTokenAddress: '0x0000000000000000000000000000000000000000',
+  },
+]

--- a/frontend/src/config/geyser.ts
+++ b/frontend/src/config/geyser.ts
@@ -1,10 +1,11 @@
-import { StakingToken } from './stakingToken'
+import { StakingToken } from '../constants'
 
 export type GeyserConfig = {
   name: string
   address: string
   stakingToken: StakingToken
   platformTokenAddress?: string
+  platformTokenClaimLink?: string
 }
 
 export const geysersConfig: GeyserConfig[] = [
@@ -12,18 +13,21 @@ export const geysersConfig: GeyserConfig[] = [
     name: 'Trinity V1 (Balancer BTC-ETH-AMPL)',
     address: '0x0dcd1bf9a1b36ce34237eeafef220932846bcd82',
     stakingToken: StakingToken.MOCK,
-    platformTokenAddress: '0x0000000000000000000000000000000000000000',
+    // platformTokenAddress: '0x0000000000000000000000000000000000000000',
+    // platformTokenClaimLink: 'https://claim.balancer.fi/#/',
   },
   {
     name: 'Trinity V2 (Balancer BTC-ETH-AMPL)',
     address: '0x4a679253410272dd5232b3ff7cf5dbb88f295319',
     stakingToken: StakingToken.MOCK,
-    platformTokenAddress: '0x0000000000000000000000000000000000000000',
+    // platformTokenAddress: '0x0000000000000000000000000000000000000000',
+    // platformTokenClaimLink: 'https://claim.balancer.fi/#/',
   },
   {
     name: 'Trinity V3 (Balancer BTC-ETH-AMPL)',
     address: '0x59b670e9fa9d0a427751af201d676719a970857b',
     stakingToken: StakingToken.MOCK,
-    platformTokenAddress: '0x0000000000000000000000000000000000000000',
+    // platformTokenAddress: '0x0000000000000000000000000000000000000000',
+    // platformTokenClaimLink: 'https://claim.balancer.fi/#/',
   },
 ]

--- a/frontend/src/config/stakingToken.ts
+++ b/frontend/src/config/stakingToken.ts
@@ -1,0 +1,54 @@
+import { BigNumber, Signer } from 'ethers'
+import { formatUnits } from 'ethers/lib/utils'
+import { toChecksumAddress } from 'web3-utils'
+import { ERC20Balance } from '../sdk'
+import { StakingTokenInfo, TokenComposition } from '../types'
+import { getCurrentPrice } from '../utils/price'
+import { getTokenInfo } from '../utils/tokens'
+
+export enum StakingToken {
+  MOCK,
+}
+
+type StakingTokenFunction = (tokenAddress: string, signer: Signer) => Promise<StakingTokenInfo>
+
+export const STAKING_TOKEN_FUNCTION_MAPPING: Record<StakingToken, StakingTokenFunction> = {
+  [StakingToken.MOCK]: (address: string, signer: Signer) => getMockLPToken(address, signer),
+}
+
+const getTokenComposition = async (
+  tokenAddress: string,
+  stakingTokenAddress: string,
+  signer: Signer,
+  weight: number,
+): Promise<TokenComposition> => {
+  const { name, symbol, decimals } = await getTokenInfo(tokenAddress, signer)
+  const price = await getCurrentPrice(symbol)
+  const balance = await ERC20Balance(tokenAddress, stakingTokenAddress, signer)
+
+  const balanceNumber = parseInt(formatUnits(balance as BigNumber, decimals), 10)
+
+  return {
+    address: tokenAddress,
+    name,
+    symbol,
+    balance: balanceNumber,
+    decimals,
+    value: price * balanceNumber,
+    weight,
+  }
+}
+
+const getMockLPToken = async (tokenAddress: string, signer: Signer): Promise<StakingTokenInfo> => {
+  const price = ((await getCurrentPrice('AMPL')) + (await getCurrentPrice('BAL'))) / 2
+  return {
+    address: toChecksumAddress(tokenAddress),
+    name: `MOCK-AMPL-BAL Liquidity Token`,
+    symbol: `MOCK-AMPL-BAL`,
+    decimals: 18,
+    price,
+    totalSupply: 100000,
+    marketCap: 100000 * price,
+    composition: [],
+  }
+}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -12,8 +12,20 @@ export const VaultStateColors: Record<VaultState, string> = {
   [VaultState.INACTIVE]: NamedColors.RED_ORANGE,
 }
 
-const second = 1000
-export const POLL_INTERVAL = 5 * second
+const MS_PER_SEC = 1000
+
+export const HOUR_IN_SEC = 3600
+export const DAY_IN_SEC = 24 * HOUR_IN_SEC
+export const YEAR_IN_SEC = 365 * DAY_IN_SEC
+
+export const HOUR_IN_MS = HOUR_IN_SEC * MS_PER_SEC
+export const DAY_IN_MS = DAY_IN_SEC * MS_PER_SEC
+export const YEAR_IN_MS = YEAR_IN_SEC * MS_PER_SEC
+
+export const POLL_INTERVAL = 5 * MS_PER_SEC
+
+// pseudo permanent cache time
+export const CONST_CACHE_TIME_MS = YEAR_IN_MS
 
 export const MOCK_ERC_20_ADDRESS = '0x0165878A594ca255338adfa4d48449f69242Eb8F'
 

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -33,3 +33,8 @@ export enum GeyserView {
   STAKE = 'Stake',
   UNSTAKE = 'Unstake',
 }
+
+// Staking tokens
+export enum StakingToken {
+  MOCK,
+}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,17 +1,3 @@
-import { NamedColors } from './styling/colors'
-
-export enum VaultState {
-  ACTIVE,
-  STALE,
-  INACTIVE,
-}
-
-export const VaultStateColors: Record<VaultState, string> = {
-  [VaultState.ACTIVE]: NamedColors.APPLE,
-  [VaultState.STALE]: NamedColors.SCHOOL_BUS_YELLOW,
-  [VaultState.INACTIVE]: NamedColors.RED_ORANGE,
-}
-
 const MS_PER_SEC = 1000
 
 export const HOUR_IN_SEC = 3600
@@ -36,5 +22,13 @@ export enum GeyserView {
 
 // Staking tokens
 export enum StakingToken {
+  // for testing
   MOCK,
+
+  // for mainnet
+  UNISWAP_V2,
+  SUSHISWAP,
+  MOONISWAP_V1,
+  BALANCER_V1,
+  BALANCER_SMART_POOL_V1,
 }

--- a/frontend/src/context/GeyserContext.tsx
+++ b/frontend/src/context/GeyserContext.tsx
@@ -6,8 +6,9 @@ import { GET_GEYSERS } from '../queries/geyser'
 import { Geyser, StakingTokenInfo, TokenInfo } from '../types'
 import Web3Context from './Web3Context'
 import { POLL_INTERVAL } from '../constants'
-import { defaultStakingTokenInfo, defaultTokenInfo, getTokenInfo, getStakingTokenInfo } from '../utils/tokens'
+import { defaultTokenInfo, getTokenInfo } from '../utils/token'
 import { GeyserConfig, geysersConfig } from '../config/geyser'
+import { defaultStakingTokenInfo, getStakingTokenInfo } from '../utils/stakingToken'
 
 export const GeyserContext = createContext<{
   geysers: Geyser[]
@@ -18,6 +19,7 @@ export const GeyserContext = createContext<{
   rewardTokenInfo: TokenInfo
   platformTokenInfo: TokenInfo
   geyserAddressToName: Map<string, string>
+  selectedGeyserConfig: GeyserConfig | null
 }>({
   geysers: [],
   selectedGeyser: null,
@@ -27,6 +29,7 @@ export const GeyserContext = createContext<{
   rewardTokenInfo: defaultTokenInfo(),
   platformTokenInfo: defaultTokenInfo(),
   geyserAddressToName: new Map<string, string>(),
+  selectedGeyserConfig: null,
 })
 
 export const GeyserContextProvider: React.FC = ({ children }) => {
@@ -105,6 +108,7 @@ export const GeyserContextProvider: React.FC = ({ children }) => {
         rewardTokenInfo,
         platformTokenInfo,
         geyserAddressToName,
+        selectedGeyserConfig,
       }}
     >
       {children}

--- a/frontend/src/context/StatsContext.tsx
+++ b/frontend/src/context/StatsContext.tsx
@@ -29,13 +29,18 @@ export const StatsContextProvider: React.FC = ({ children }) => {
     ;(async () => {
       try {
         if (signer && selectedGeyser) {
-          const newGeyserStats = await getGeyserStats(selectedGeyser, stakingTokenInfo)
+          const newGeyserStats = await getGeyserStats(selectedGeyser, stakingTokenInfo, rewardTokenInfo)
           const newUserStats = await getUserStats(selectedGeyser, selectedVault, currentLock, stakingTokenInfo, rewardTokenInfo, signer)
-          const newVaultStats = await getVaultStats(stakingTokenInfo, platformTokenInfo, selectedVault, signer)
+          const newVaultStats = await getVaultStats(stakingTokenInfo, platformTokenInfo, rewardTokenInfo, selectedVault, currentLock, signer)
           if (mounted) {
             setGeyserStats(newGeyserStats)
             setUserStats(newUserStats)
             setVaultStats(newVaultStats)
+            console.log({
+              newGeyserStats,
+              newUserStats,
+              newVaultStats,
+            })
           }
         }
       } catch (e) {

--- a/frontend/src/context/StatsContext.tsx
+++ b/frontend/src/context/StatsContext.tsx
@@ -1,4 +1,8 @@
+import { BigNumberish } from 'ethers'
+import { formatUnits } from 'ethers/lib/utils'
 import React, { createContext, useContext, useEffect, useState } from 'react'
+import { toChecksumAddress } from 'web3-utils'
+import { getCurrentStakeReward } from '../sdk/stats'
 import { GeyserStats, UserStats, VaultStats } from '../types'
 import { defaultGeyserStats, defaultUserStats, defaultVaultStats, getGeyserStats, getUserStats, getVaultStats } from '../utils/stats'
 import { GeyserContext } from './GeyserContext'
@@ -9,10 +13,12 @@ export const StatsContext = createContext<{
   userStats: UserStats
   geyserStats: GeyserStats
   vaultStats: VaultStats
+  computeRewardsFromUnstake: (unstakeAmount: BigNumberish) => Promise<number>
 }>({
   userStats: defaultUserStats(),
   geyserStats: defaultGeyserStats(),
   vaultStats: defaultVaultStats(),
+  computeRewardsFromUnstake: async () => 0,
 })
 
 export const StatsContextProvider: React.FC = ({ children }) => {
@@ -21,8 +27,19 @@ export const StatsContextProvider: React.FC = ({ children }) => {
   const [vaultStats, setVaultStats] = useState<VaultStats>(defaultVaultStats())
 
   const { signer } = useContext(Web3Context)
-  const { selectedGeyser, rewardTokenInfo, stakingTokenInfo, platformTokenInfo } = useContext(GeyserContext)
+  const { selectedGeyser, rewardTokenInfo, stakingTokenInfo, platformTokenInfos } = useContext(GeyserContext)
   const { selectedVault, currentLock } = useContext(VaultContext)
+
+  const computeRewardsFromUnstake = async (unstakeAmount: BigNumberish) => {
+    const { decimals } = rewardTokenInfo
+    if (selectedGeyser && selectedVault && signer && decimals) {
+      const vaultAddress = toChecksumAddress(selectedVault.id)
+      const geyserAddress = toChecksumAddress(selectedGeyser.id)
+      const computedRewards = await getCurrentStakeReward(vaultAddress, geyserAddress, unstakeAmount, signer)
+      return parseFloat(formatUnits(computedRewards, decimals))
+    }
+    return 0
+  }
 
   useEffect(() => {
     let mounted = true
@@ -31,16 +48,11 @@ export const StatsContextProvider: React.FC = ({ children }) => {
         if (signer && selectedGeyser) {
           const newGeyserStats = await getGeyserStats(selectedGeyser, stakingTokenInfo, rewardTokenInfo)
           const newUserStats = await getUserStats(selectedGeyser, selectedVault, currentLock, stakingTokenInfo, rewardTokenInfo, signer)
-          const newVaultStats = await getVaultStats(stakingTokenInfo, platformTokenInfo, rewardTokenInfo, selectedVault, currentLock, signer)
+          const newVaultStats = await getVaultStats(stakingTokenInfo, platformTokenInfos, rewardTokenInfo, selectedVault, currentLock, signer)
           if (mounted) {
             setGeyserStats(newGeyserStats)
             setUserStats(newUserStats)
             setVaultStats(newVaultStats)
-            console.log({
-              newGeyserStats,
-              newUserStats,
-              newVaultStats,
-            })
           }
         }
       } catch (e) {
@@ -51,7 +63,7 @@ export const StatsContextProvider: React.FC = ({ children }) => {
   }, [signer, selectedGeyser, selectedVault, currentLock])
 
   return (
-    <StatsContext.Provider value={{ userStats, geyserStats, vaultStats }}>
+    <StatsContext.Provider value={{ userStats, geyserStats, vaultStats, computeRewardsFromUnstake }}>
       {children}
     </StatsContext.Provider>
   )

--- a/frontend/src/context/StatsContext.tsx
+++ b/frontend/src/context/StatsContext.tsx
@@ -1,0 +1,53 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+import { GeyserStats, UserStats, VaultStats } from '../types'
+import { defaultGeyserStats, defaultUserStats, defaultVaultStats, getGeyserStats, getUserStats, getVaultStats } from '../utils/stats'
+import { GeyserContext } from './GeyserContext'
+import { VaultContext } from './VaultContext'
+import Web3Context from './Web3Context'
+
+export const StatsContext = createContext<{
+  userStats: UserStats
+  geyserStats: GeyserStats
+  vaultStats: VaultStats
+}>({
+  userStats: defaultUserStats(),
+  geyserStats: defaultGeyserStats(),
+  vaultStats: defaultVaultStats(),
+})
+
+export const StatsContextProvider: React.FC = ({ children }) => {
+  const [userStats, setUserStats] = useState<UserStats>(defaultUserStats())
+  const [geyserStats, setGeyserStats] = useState<GeyserStats>(defaultGeyserStats())
+  const [vaultStats, setVaultStats] = useState<VaultStats>(defaultVaultStats())
+
+  const { signer } = useContext(Web3Context)
+  const { selectedGeyser, rewardTokenInfo, stakingTokenInfo, platformTokenInfo } = useContext(GeyserContext)
+  const { selectedVault, currentLock } = useContext(VaultContext)
+
+  useEffect(() => {
+    let mounted = true
+    ;(async () => {
+      try {
+        if (signer && selectedGeyser) {
+          const newGeyserStats = await getGeyserStats(selectedGeyser, stakingTokenInfo)
+          const newUserStats = await getUserStats(selectedGeyser, selectedVault, currentLock, stakingTokenInfo, rewardTokenInfo, signer)
+          const newVaultStats = await getVaultStats(stakingTokenInfo, platformTokenInfo, selectedVault, signer)
+          if (mounted) {
+            setGeyserStats(newGeyserStats)
+            setUserStats(newUserStats)
+            setVaultStats(newVaultStats)
+          }
+        }
+      } catch (e) {
+        console.error(e)
+      }
+    })()
+    return () => { mounted = false }
+  }, [signer, selectedGeyser, selectedVault, currentLock])
+
+  return (
+    <StatsContext.Provider value={{ userStats, geyserStats, vaultStats }}>
+      {children}
+    </StatsContext.Provider>
+  )
+}

--- a/frontend/src/context/VaultContext.tsx
+++ b/frontend/src/context/VaultContext.tsx
@@ -47,6 +47,8 @@ export const VaultContextProvider: React.FC = ({ children }) => {
         selectVault(userVaults[0])
       } else if (userVaults.length > 0) {
         setSelectedVault(userVaults.find((vault) => vault.id === selectedVault?.id) || userVaults[0])
+      } else {
+        setSelectedVault(null)
       }
     }
   }, [vaultData, selectedVault])

--- a/frontend/src/context/VaultContext.tsx
+++ b/frontend/src/context/VaultContext.tsx
@@ -11,11 +11,13 @@ export const VaultContext = createContext<{
   vaults: Vault[]
   selectedVault: Vault | null
   selectVault: (arg0: Vault) => void
+  selectVaultById: (id: string) => void
   currentLock: Lock | null
 }>({
   vaults: [],
   selectedVault: null,
   selectVault: () => {},
+  selectVaultById: () => {},
   currentLock: null,
 })
 
@@ -31,6 +33,7 @@ export const VaultContextProvider: React.FC = ({ children }) => {
   const [currentLock, setCurrentLock] = useState<Lock | null>(null)
 
   const selectVault = (vault: Vault) => setSelectedVault(vault)
+  const selectVaultById = (id: string) => setSelectedVault(vaults.find(vault => vault.id === id) || selectedVault)
 
   useEffect(() => {
     if (address) getVaults({ variables: { id: address } })
@@ -52,8 +55,7 @@ export const VaultContextProvider: React.FC = ({ children }) => {
     if (selectedVault && selectedGeyser) {
       const { stakingToken } = selectedGeyser
       const lockId = `${selectedVault.id}-${selectedGeyser.id}-${stakingToken}`
-      const lock = selectedVault.locks.find((lock) => lock.id === lockId) || null
-      setCurrentLock(lock)
+      setCurrentLock(selectedVault.locks.find((lock) => lock.id === lockId) || null)
     }
   }, [selectedVault, selectedGeyser])
 
@@ -65,6 +67,7 @@ export const VaultContextProvider: React.FC = ({ children }) => {
         vaults,
         selectedVault,
         selectVault,
+        selectVaultById,
         currentLock,
       }}
     >

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -1,6 +1,6 @@
 import { BigNumber } from 'ethers'
-import { createContext, useContext, useEffect, useState } from 'react'
-import { getTokenBalance } from '../sdk'
+import { createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { ERC20Balance } from '../sdk'
 import { GeyserContext } from './GeyserContext'
 import Web3Context from './Web3Context'
 
@@ -17,16 +17,18 @@ export const WalletContextProvider: React.FC = ({ children }) => {
   const { signer } = useContext(Web3Context)
   const { selectedGeyser } = useContext(GeyserContext)
 
-  const getWalletAmount = async () => {
+  const getWalletAmount = useCallback(async () => {
     if (selectedGeyser && signer) {
       const { stakingToken } = selectedGeyser
       try {
-        return getTokenBalance(stakingToken, await signer.getAddress(), signer)
+        return await ERC20Balance(stakingToken, await signer.getAddress(), signer)
       } catch (e) {
         console.error(e)
+        return BigNumber.from('0')
       }
     }
-  }
+    return BigNumber.from('0')
+  }, [selectedGeyser, signer])
 
   const refreshWalletAmount = () => getWalletAmount()
 
@@ -43,7 +45,7 @@ export const WalletContextProvider: React.FC = ({ children }) => {
     return () => {
       mounted = false
     }
-  }, [selectedGeyser, signer, getWalletAmount])
+  }, [getWalletAmount])
 
   return <WalletContext.Provider value={{ walletAmount, refreshWalletAmount }}>{children}</WalletContext.Provider>
 }

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -21,7 +21,8 @@ export const WalletContextProvider: React.FC = ({ children }) => {
     if (selectedGeyser && signer) {
       const { stakingToken } = selectedGeyser
       try {
-        return await ERC20Balance(stakingToken, await signer.getAddress(), signer)
+        const balance = await ERC20Balance(stakingToken, await signer.getAddress(), signer)
+        return balance
       } catch (e) {
         console.error(e)
         return BigNumber.from('0')

--- a/frontend/src/context/Web3Context.tsx
+++ b/frontend/src/context/Web3Context.tsx
@@ -7,15 +7,17 @@ class Provider extends ethers.providers.Web3Provider {}
 
 const Web3Context = createContext<{
   address?: string
-  wallet?: Wallet
+  wallet: Wallet | null
   onboard?: API
-  provider?: Provider
+  provider: Provider | null
   signer?: Signer
   selectWallet: () => Promise<boolean>
   ready: boolean
 }>({
   selectWallet: async () => false,
   ready: false,
+  wallet: null,
+  provider: null,
 })
 
 interface Subscriptions {
@@ -35,9 +37,9 @@ const initOnboard = (subscriptions: Subscriptions): API => {
 
 const Web3Provider: React.FC = ({ children }) => {
   const [address, setAddress] = useState<string>()
-  const [wallet, setWallet] = useState<Wallet>()
+  const [wallet, setWallet] = useState<Wallet | null>(null)
   const [onboard, setOnboard] = useState<API>()
-  const [provider, setProvider] = useState<Provider>()
+  const [provider, setProvider] = useState<Provider | null>(null)
   const [signer, setSigner] = useState<Signer>()
   const [ready, setReady] = useState(false)
 
@@ -58,9 +60,8 @@ const Web3Provider: React.FC = ({ children }) => {
         if (w?.provider?.selectedAddress) {
           updateWallet(w)
         } else {
-          // TODO: favour using nulls over undefined when explicitly set
-          setProvider(undefined)
-          setWallet(undefined)
+          setProvider(null)
+          setWallet(null)
         }
       },
     })

--- a/frontend/src/queries/geyser.ts
+++ b/frontend/src/queries/geyser.ts
@@ -19,6 +19,7 @@ export const GET_GEYSERS = gql`
         start
       }
       totalRewardsClaimed
+      lastUpdate
     }
   }
 `

--- a/frontend/src/queries/geyser.ts
+++ b/frontend/src/queries/geyser.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client'
 
 export const GET_GEYSERS = gql`
-  query getGeysers {
-    geysers(first: 1000) {
+  query getGeysers($ids: [ID!]!) {
+    geysers(first: 1000, where: { id_in: $ids }) {
       id
       rewardToken
       stakingToken
@@ -13,6 +13,12 @@ export const GET_GEYSERS = gql`
       scalingCeiling
       scalingTime
       unlockedReward
+      rewardSchedules(first: 1000) {
+        id
+        duration
+        start
+      }
+      totalRewardsClaimed
     }
   }
 `

--- a/frontend/src/sdk/stats.ts
+++ b/frontend/src/sdk/stats.ts
@@ -1,0 +1,34 @@
+import { BigNumber, Contract, Signer } from 'ethers'
+import { loadNetworkConfig } from './utils'
+
+async function _execGeyserFunction<T>(
+  geyserAddress: string,
+  signer: Signer,
+  fnc: string,
+  args: any[] = [],
+): Promise<T> {
+  const config = await loadNetworkConfig(signer)
+  const geyser = new Contract(geyserAddress, config.GeyserTemplate.abi, signer)
+  return geyser[fnc](...args) as Promise<T>
+}
+
+export const getCurrentVaultReward = async (vaultAddress: string, geyserAddress: string, signer: Signer) => {
+  return _execGeyserFunction<BigNumber>(geyserAddress, signer, 'getCurrentVaultReward', [vaultAddress])
+}
+
+export const getFutureVaultReward = async (
+  vaultAddress: string,
+  geyserAddress: string,
+  timestamp: number,
+  signer: Signer,
+) => {
+  return _execGeyserFunction<BigNumber>(geyserAddress, signer, 'getFutureVaultReward', [vaultAddress, timestamp])
+}
+
+export const getCurrentUnlockedRewards = async (geyserAddress: string, signer: Signer) => {
+  return _execGeyserFunction<BigNumber>(geyserAddress, signer, 'getCurrentUnlockedRewards')
+}
+
+export const getFutureUnlockedRewards = async (geyserAddress: string, timestamp: number, signer: Signer) => {
+  return _execGeyserFunction<BigNumber>(geyserAddress, signer, 'getFutureUnlockedRewards', [timestamp])
+}

--- a/frontend/src/sdk/stats.ts
+++ b/frontend/src/sdk/stats.ts
@@ -1,4 +1,4 @@
-import { BigNumber, Contract, Signer } from 'ethers'
+import { BigNumber, BigNumberish, Contract, Signer } from 'ethers'
 import { loadNetworkConfig } from './utils'
 
 async function _execGeyserFunction<T>(
@@ -31,4 +31,13 @@ export const getCurrentUnlockedRewards = async (geyserAddress: string, signer: S
 
 export const getFutureUnlockedRewards = async (geyserAddress: string, timestamp: number, signer: Signer) => {
   return _execGeyserFunction<BigNumber>(geyserAddress, signer, 'getFutureUnlockedRewards', [timestamp])
+}
+
+export const getCurrentStakeReward = async (
+  vaultAddress: string,
+  geyserAddress: string,
+  amount: BigNumberish,
+  signer: Signer,
+) => {
+  return _execGeyserFunction<BigNumber>(geyserAddress, signer, 'getCurrentStakeReward', [vaultAddress, amount])
 }

--- a/frontend/src/sdk/tokens.ts
+++ b/frontend/src/sdk/tokens.ts
@@ -2,12 +2,7 @@ import { BigNumber, Contract, Signer } from 'ethers'
 import { parseUnits } from 'ethers/lib/utils'
 import { ERC20_ABI } from './abis'
 
-export const getTokenBalance = async (tokenAddress: string, holderAddress: string, signer: Signer) => {
-  const contract = new Contract(tokenAddress, ERC20_ABI, signer)
-  return contract.balanceOf(holderAddress) as Promise<BigNumber>
-}
-
-function _execTokenFunction<T>(tokenAddress: string, signer: Signer, fnc: string, args = []): Promise<T> {
+function _execTokenFunction<T>(tokenAddress: string, signer: Signer, fnc: string, args: any[] = []): Promise<T> {
   const token = new Contract(tokenAddress, ERC20_ABI, signer)
   return token[fnc](...args) as Promise<T>
 }
@@ -22,6 +17,10 @@ export const ERC20Name = async (tokenAddress: string, signer: Signer) => {
 
 export const ERC20Symbol = async (tokenAddress: string, signer: Signer) => {
   return _execTokenFunction<string>(tokenAddress, signer, 'symbol')
+}
+
+export const ERC20Balance = async (tokenAddress: string, holderAddress: string, signer: Signer) => {
+  return _execTokenFunction<BigNumber>(tokenAddress, signer, 'balanceOf', [holderAddress])
 }
 
 export const parseUnitsWithDecimals = async (value: string, tokenAddress: string, signer: Signer) => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'ethers'
+import { StakingToken } from './constants'
 
 type ClaimedReward = {
   id: string
@@ -84,7 +84,7 @@ export type GeyserStats = {
 export type VaultStats = {
   id: string
   stakingTokenBalance: number
-  platformTokenBalance: number
+  platformTokenBalances: number[]
   rewardTokenBalance: number
   currentStake: number
 }
@@ -93,4 +93,16 @@ export type UserStats = {
   apy: number
   currentMultiplier: number
   currentReward: number
+}
+
+export type GeyserConfig = {
+  name: string
+  address: string
+  stakingToken: StakingToken
+  platformTokenConfigs: PlatformTokenConfig[]
+}
+
+export type PlatformTokenConfig = {
+  address: string
+  claimLink?: string
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -20,6 +20,12 @@ export enum GeyserStatus {
   SHUTDOWN = 'Shutdown',
 }
 
+export type RewardSchedule = {
+  id: string
+  duration: string
+  start: string
+}
+
 export type Geyser = {
   id: string
   rewardToken: string
@@ -31,6 +37,9 @@ export type Geyser = {
   scalingCeiling: string
   scalingTime: string
   unlockedReward: string
+  rewardSchedules: RewardSchedule[]
+  totalRewardsClaimed: string
+  lastUpdate: string
 }
 
 export type Lock = {
@@ -38,10 +47,51 @@ export type Lock = {
   geyser: Geyser
   token: string
   amount: string
+  lastUpdate: string
+  stakeUnits: string
 }
 
-export type TokenBalance = {
+export type TokenInfo = {
   address: string
-  balance: BigNumber
   name: string
+  symbol: string
+  decimals: number
+}
+
+export type TokenComposition = {
+  address: string
+  name: string
+  symbol: string
+  decimals: number
+  balance: number
+  value: number
+  weight: number
+}
+
+export type StakingTokenInfo = TokenInfo & {
+  price: number
+  totalSupply: number
+  marketCap: number
+  composition: TokenComposition[]
+}
+
+export type GeyserStats = {
+  duration: number
+  totalDeposit: number
+  totalRewardsClaimed: BigNumber
+}
+
+export type VaultStats = {
+  id: string
+  stakingTokenBalance: BigNumber
+  platformTokenBalance: BigNumber
+}
+
+export type UserStats = {
+  apy: number
+  currentMultiplier: number
+  currentReward: BigNumber
+
+  // want?
+  currentStake?: BigNumber
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -78,20 +78,19 @@ export type StakingTokenInfo = TokenInfo & {
 export type GeyserStats = {
   duration: number
   totalDeposit: number
-  totalRewardsClaimed: BigNumber
+  totalRewardsClaimed: number
 }
 
 export type VaultStats = {
   id: string
-  stakingTokenBalance: BigNumber
-  platformTokenBalance: BigNumber
+  stakingTokenBalance: number
+  platformTokenBalance: number
+  rewardTokenBalance: number
+  currentStake: number
 }
 
 export type UserStats = {
   apy: number
   currentMultiplier: number
-  currentReward: BigNumber
-
-  // want?
-  currentStake?: BigNumber
+  currentReward: number
 }

--- a/frontend/src/utils/abis/BalancerBPoolV1.ts
+++ b/frontend/src/utils/abis/BalancerBPoolV1.ts
@@ -1,0 +1,1630 @@
+export const BALANCER_BPOOL_V1_ABI = [
+  {
+    inputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'src',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'dst',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amt',
+        type: 'uint256',
+      },
+    ],
+    name: 'Approval',
+    type: 'event',
+  },
+  {
+    anonymous: true,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes4',
+        name: 'sig',
+        type: 'bytes4',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes',
+        name: 'data',
+        type: 'bytes',
+      },
+    ],
+    name: 'LOG_CALL',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'tokenOut',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'tokenAmountOut',
+        type: 'uint256',
+      },
+    ],
+    name: 'LOG_EXIT',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'tokenIn',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'tokenAmountIn',
+        type: 'uint256',
+      },
+    ],
+    name: 'LOG_JOIN',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'tokenIn',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'tokenOut',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'tokenAmountIn',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'tokenAmountOut',
+        type: 'uint256',
+      },
+    ],
+    name: 'LOG_SWAP',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'src',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'dst',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amt',
+        type: 'uint256',
+      },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'BONE',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'BPOW_PRECISION',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'EXIT_FEE',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'INIT_POOL_SUPPLY',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'MAX_BOUND_TOKENS',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'MAX_BPOW_BASE',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'MAX_FEE',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'MAX_IN_RATIO',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'MAX_OUT_RATIO',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'MAX_TOTAL_WEIGHT',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'MAX_WEIGHT',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'MIN_BALANCE',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'MIN_BOUND_TOKENS',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'MIN_BPOW_BASE',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'MIN_FEE',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'MIN_WEIGHT',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'src',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'dst',
+        type: 'address',
+      },
+    ],
+    name: 'allowance',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'dst',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amt',
+        type: 'uint256',
+      },
+    ],
+    name: 'approve',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'whom',
+        type: 'address',
+      },
+    ],
+    name: 'balanceOf',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'balance',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'denorm',
+        type: 'uint256',
+      },
+    ],
+    name: 'bind',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenBalanceIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenWeightIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenBalanceOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenWeightOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'swapFee',
+        type: 'uint256',
+      },
+    ],
+    name: 'calcInGivenOut',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountIn',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenBalanceIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenWeightIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenBalanceOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenWeightOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'swapFee',
+        type: 'uint256',
+      },
+    ],
+    name: 'calcOutGivenIn',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountOut',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenBalanceOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenWeightOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'poolSupply',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'totalWeight',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'swapFee',
+        type: 'uint256',
+      },
+    ],
+    name: 'calcPoolInGivenSingleOut',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'poolAmountIn',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenBalanceIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenWeightIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'poolSupply',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'totalWeight',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'swapFee',
+        type: 'uint256',
+      },
+    ],
+    name: 'calcPoolOutGivenSingleIn',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'poolAmountOut',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenBalanceIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenWeightIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'poolSupply',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'totalWeight',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'poolAmountOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'swapFee',
+        type: 'uint256',
+      },
+    ],
+    name: 'calcSingleInGivenPoolOut',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountIn',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenBalanceOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenWeightOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'poolSupply',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'totalWeight',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'poolAmountIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'swapFee',
+        type: 'uint256',
+      },
+    ],
+    name: 'calcSingleOutGivenPoolIn',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountOut',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenBalanceIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenWeightIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenBalanceOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenWeightOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'swapFee',
+        type: 'uint256',
+      },
+    ],
+    name: 'calcSpotPrice',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'spotPrice',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'decimals',
+    outputs: [
+      {
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'dst',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amt',
+        type: 'uint256',
+      },
+    ],
+    name: 'decreaseApproval',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'poolAmountIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256[]',
+        name: 'minAmountsOut',
+        type: 'uint256[]',
+      },
+    ],
+    name: 'exitPool',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'tokenOut',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'maxPoolAmountIn',
+        type: 'uint256',
+      },
+    ],
+    name: 'exitswapExternAmountOut',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'poolAmountIn',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'tokenOut',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'poolAmountIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'minAmountOut',
+        type: 'uint256',
+      },
+    ],
+    name: 'exitswapPoolAmountIn',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountOut',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [],
+    name: 'finalize',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'getBalance',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'getColor',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'getController',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'getCurrentTokens',
+    outputs: [
+      {
+        internalType: 'address[]',
+        name: 'tokens',
+        type: 'address[]',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'getDenormalizedWeight',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'getFinalTokens',
+    outputs: [
+      {
+        internalType: 'address[]',
+        name: 'tokens',
+        type: 'address[]',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'getNormalizedWeight',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'getNumTokens',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'tokenIn',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'tokenOut',
+        type: 'address',
+      },
+    ],
+    name: 'getSpotPrice',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'spotPrice',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'tokenIn',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'tokenOut',
+        type: 'address',
+      },
+    ],
+    name: 'getSpotPriceSansFee',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'spotPrice',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'getSwapFee',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'getTotalDenormalizedWeight',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'gulp',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'dst',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amt',
+        type: 'uint256',
+      },
+    ],
+    name: 'increaseApproval',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 't',
+        type: 'address',
+      },
+    ],
+    name: 'isBound',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'isFinalized',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'isPublicSwap',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'poolAmountOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256[]',
+        name: 'maxAmountsIn',
+        type: 'uint256[]',
+      },
+    ],
+    name: 'joinPool',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'tokenIn',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'minPoolAmountOut',
+        type: 'uint256',
+      },
+    ],
+    name: 'joinswapExternAmountIn',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'poolAmountOut',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'tokenIn',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'poolAmountOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'maxAmountIn',
+        type: 'uint256',
+      },
+    ],
+    name: 'joinswapPoolAmountOut',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountIn',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'name',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'balance',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'denorm',
+        type: 'uint256',
+      },
+    ],
+    name: 'rebind',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'manager',
+        type: 'address',
+      },
+    ],
+    name: 'setController',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'bool',
+        name: 'public_',
+        type: 'bool',
+      },
+    ],
+    name: 'setPublicSwap',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'swapFee',
+        type: 'uint256',
+      },
+    ],
+    name: 'setSwapFee',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'tokenIn',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: 'tokenOut',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'minAmountOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'maxPrice',
+        type: 'uint256',
+      },
+    ],
+    name: 'swapExactAmountIn',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'spotPriceAfter',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'tokenIn',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'maxAmountIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: 'tokenOut',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'maxPrice',
+        type: 'uint256',
+      },
+    ],
+    name: 'swapExactAmountOut',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'spotPriceAfter',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'symbol',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'dst',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amt',
+        type: 'uint256',
+      },
+    ],
+    name: 'transfer',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'src',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'dst',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amt',
+        type: 'uint256',
+      },
+    ],
+    name: 'transferFrom',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'unbind',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+]

--- a/frontend/src/utils/abis/BalancerCRPV1.ts
+++ b/frontend/src/utils/abis/BalancerCRPV1.ts
@@ -1,0 +1,1261 @@
+export const BALANCER_CRP_V1_ABI = [
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'factoryAddress',
+        type: 'address',
+      },
+      {
+        components: [
+          {
+            internalType: 'string',
+            name: 'poolTokenSymbol',
+            type: 'string',
+          },
+          {
+            internalType: 'string',
+            name: 'poolTokenName',
+            type: 'string',
+          },
+          {
+            internalType: 'address[]',
+            name: 'constituentTokens',
+            type: 'address[]',
+          },
+          {
+            internalType: 'uint256[]',
+            name: 'tokenBalances',
+            type: 'uint256[]',
+          },
+          {
+            internalType: 'uint256[]',
+            name: 'tokenWeights',
+            type: 'uint256[]',
+          },
+          {
+            internalType: 'uint256',
+            name: 'swapFee',
+            type: 'uint256',
+          },
+        ],
+        internalType: 'struct ConfigurableRightsPool.PoolParams',
+        name: 'poolParams',
+        type: 'tuple',
+      },
+      {
+        components: [
+          {
+            internalType: 'bool',
+            name: 'canPauseSwapping',
+            type: 'bool',
+          },
+          {
+            internalType: 'bool',
+            name: 'canChangeSwapFee',
+            type: 'bool',
+          },
+          {
+            internalType: 'bool',
+            name: 'canChangeWeights',
+            type: 'bool',
+          },
+          {
+            internalType: 'bool',
+            name: 'canAddRemoveTokens',
+            type: 'bool',
+          },
+          {
+            internalType: 'bool',
+            name: 'canWhitelistLPs',
+            type: 'bool',
+          },
+          {
+            internalType: 'bool',
+            name: 'canChangeCap',
+            type: 'bool',
+          },
+        ],
+        internalType: 'struct RightsManager.Rights',
+        name: 'rightsStruct',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Approval',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'oldCap',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'newCap',
+        type: 'uint256',
+      },
+    ],
+    name: 'CapChanged',
+    type: 'event',
+  },
+  {
+    anonymous: true,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes4',
+        name: 'sig',
+        type: 'bytes4',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes',
+        name: 'data',
+        type: 'bytes',
+      },
+    ],
+    name: 'LogCall',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'tokenOut',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'tokenAmountOut',
+        type: 'uint256',
+      },
+    ],
+    name: 'LogExit',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'tokenIn',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'tokenAmountIn',
+        type: 'uint256',
+      },
+    ],
+    name: 'LogJoin',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'pool',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'caller',
+        type: 'address',
+      },
+    ],
+    name: 'NewTokenCommitted',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'previousOwner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnershipTransferred',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'DECIMALS',
+    outputs: [
+      {
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'DEFAULT_ADD_TOKEN_TIME_LOCK_IN_BLOCKS',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'DEFAULT_MIN_WEIGHT_CHANGE_BLOCK_PERIOD',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'NAME',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'addTokenTimeLockInBlocks',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+    ],
+    name: 'allowance',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'applyAddToken',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'approve',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'bFactory',
+    outputs: [
+      {
+        internalType: 'contract IBFactory',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'bPool',
+    outputs: [
+      {
+        internalType: 'contract IBPool',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'balanceOf',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'bspCap',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'burnPoolShareFromLib',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'provider',
+        type: 'address',
+      },
+    ],
+    name: 'canProvideLiquidity',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'balance',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'denormalizedWeight',
+        type: 'uint256',
+      },
+    ],
+    name: 'commitAddToken',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'initialSupply',
+        type: 'uint256',
+      },
+    ],
+    name: 'createPool',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'initialSupply',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'minimumWeightChangeBlockPeriodParam',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'addTokenTimeLockInBlocksParam',
+        type: 'uint256',
+      },
+    ],
+    name: 'createPool',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'decimals',
+    outputs: [
+      {
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'decreaseApproval',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'poolAmountIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256[]',
+        name: 'minAmountsOut',
+        type: 'uint256[]',
+      },
+    ],
+    name: 'exitPool',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'tokenOut',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'maxPoolAmountIn',
+        type: 'uint256',
+      },
+    ],
+    name: 'exitswapExternAmountOut',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'poolAmountIn',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'tokenOut',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'poolAmountIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'minAmountOut',
+        type: 'uint256',
+      },
+    ],
+    name: 'exitswapPoolAmountIn',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountOut',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getBalancerSafeMathVersion',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getController',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'getDenormalizedWeight',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getRightsManagerVersion',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getSmartPoolManagerVersion',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'gradualUpdate',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'startBlock',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'endBlock',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'enum RightsManager.Permissions',
+        name: 'permission',
+        type: 'uint8',
+      },
+    ],
+    name: 'hasPermission',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'increaseApproval',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'isPublicSwap',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'poolAmountOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256[]',
+        name: 'maxAmountsIn',
+        type: 'uint256[]',
+      },
+    ],
+    name: 'joinPool',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'tokenIn',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountIn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'minPoolAmountOut',
+        type: 'uint256',
+      },
+    ],
+    name: 'joinswapExternAmountIn',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'poolAmountOut',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'tokenIn',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'poolAmountOut',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'maxAmountIn',
+        type: 'uint256',
+      },
+    ],
+    name: 'joinswapPoolAmountOut',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'tokenAmountIn',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'minimumWeightChangeBlockPeriod',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'mintPoolShareFromLib',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'name',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'newToken',
+    outputs: [
+      {
+        internalType: 'address',
+        name: 'addr',
+        type: 'address',
+      },
+      {
+        internalType: 'bool',
+        name: 'isCommitted',
+        type: 'bool',
+      },
+      {
+        internalType: 'uint256',
+        name: 'commitBlock',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'denorm',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'balance',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'pokeWeights',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'pullPoolShareFromLib',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'pushPoolShareFromLib',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'removeToken',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'provider',
+        type: 'address',
+      },
+    ],
+    name: 'removeWhitelistedLiquidityProvider',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'resyncWeight',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'rights',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: 'canPauseSwapping',
+        type: 'bool',
+      },
+      {
+        internalType: 'bool',
+        name: 'canChangeSwapFee',
+        type: 'bool',
+      },
+      {
+        internalType: 'bool',
+        name: 'canChangeWeights',
+        type: 'bool',
+      },
+      {
+        internalType: 'bool',
+        name: 'canAddRemoveTokens',
+        type: 'bool',
+      },
+      {
+        internalType: 'bool',
+        name: 'canWhitelistLPs',
+        type: 'bool',
+      },
+      {
+        internalType: 'bool',
+        name: 'canChangeCap',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'newCap',
+        type: 'uint256',
+      },
+    ],
+    name: 'setCap',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'setController',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bool',
+        name: 'publicSwap',
+        type: 'bool',
+      },
+    ],
+    name: 'setPublicSwap',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'swapFee',
+        type: 'uint256',
+      },
+    ],
+    name: 'setSwapFee',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'symbol',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'recipient',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'transfer',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'recipient',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'transferFrom',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'newWeight',
+        type: 'uint256',
+      },
+    ],
+    name: 'updateWeight',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256[]',
+        name: 'newWeights',
+        type: 'uint256[]',
+      },
+      {
+        internalType: 'uint256',
+        name: 'startBlock',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'endBlock',
+        type: 'uint256',
+      },
+    ],
+    name: 'updateWeightsGradually',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'provider',
+        type: 'address',
+      },
+    ],
+    name: 'whitelistLiquidityProvider',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+]

--- a/frontend/src/utils/abis/MooniswapV1Pair.ts
+++ b/frontend/src/utils/abis/MooniswapV1Pair.ts
@@ -1,0 +1,811 @@
+export const MOONISWAP_V1_PAIR_ABI = [
+  {
+    inputs: [
+      {
+        internalType: 'contract IERC20[]',
+        name: 'assets',
+        type: 'address[]',
+      },
+      {
+        internalType: 'string',
+        name: 'name',
+        type: 'string',
+      },
+      {
+        internalType: 'string',
+        name: 'symbol',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Approval',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Deposited',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'previousOwner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnershipTransferred',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'src',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'dst',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'result',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'srcBalance',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'dstBalance',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'totalSupply',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'referral',
+        type: 'address',
+      },
+    ],
+    name: 'Swapped',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Withdrawn',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'BASE_SUPPLY',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'FEE_DENOMINATOR',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'REFERRAL_SHARE',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+    ],
+    name: 'allowance',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'approve',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'balanceOf',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'decayPeriod',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'decimals',
+    outputs: [
+      {
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'subtractedValue',
+        type: 'uint256',
+      },
+    ],
+    name: 'decreaseAllowance',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256[]',
+        name: 'amounts',
+        type: 'uint256[]',
+      },
+      {
+        internalType: 'uint256[]',
+        name: 'minAmounts',
+        type: 'uint256[]',
+      },
+    ],
+    name: 'deposit',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'fairSupply',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'factory',
+    outputs: [
+      {
+        internalType: 'contract IFactory',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'fee',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract IERC20',
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'getBalanceForAddition',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract IERC20',
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'getBalanceForRemoval',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract IERC20',
+        name: 'src',
+        type: 'address',
+      },
+      {
+        internalType: 'contract IERC20',
+        name: 'dst',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'getReturn',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getTokens',
+    outputs: [
+      {
+        internalType: 'contract IERC20[]',
+        name: '',
+        type: 'address[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'addedValue',
+        type: 'uint256',
+      },
+    ],
+    name: 'increaseAllowance',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract IERC20',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'isToken',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'name',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'owner',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'renounceOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract IERC20',
+        name: 'token',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'rescueFunds',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract IERC20',
+        name: 'src',
+        type: 'address',
+      },
+      {
+        internalType: 'contract IERC20',
+        name: 'dst',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'minReturn',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: 'referral',
+        type: 'address',
+      },
+    ],
+    name: 'swap',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'result',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'symbol',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    name: 'tokens',
+    outputs: [
+      {
+        internalType: 'contract IERC20',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'recipient',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'transfer',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'recipient',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'transferFrom',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'transferOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract IERC20',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'virtualBalancesForAddition',
+    outputs: [
+      {
+        internalType: 'uint216',
+        name: 'balance',
+        type: 'uint216',
+      },
+      {
+        internalType: 'uint40',
+        name: 'time',
+        type: 'uint40',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract IERC20',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'virtualBalancesForRemoval',
+    outputs: [
+      {
+        internalType: 'uint216',
+        name: 'balance',
+        type: 'uint216',
+      },
+      {
+        internalType: 'uint40',
+        name: 'time',
+        type: 'uint40',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract IERC20',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'volumes',
+    outputs: [
+      {
+        internalType: 'uint128',
+        name: 'confirmed',
+        type: 'uint128',
+      },
+      {
+        internalType: 'uint128',
+        name: 'result',
+        type: 'uint128',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256[]',
+        name: 'minReturns',
+        type: 'uint256[]',
+      },
+    ],
+    name: 'withdraw',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+]

--- a/frontend/src/utils/abis/UniswapV2Pair.ts
+++ b/frontend/src/utils/abis/UniswapV2Pair.ts
@@ -1,0 +1,653 @@
+export const UNISWAP_V2_PAIR_ABI = [
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Approval',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount0',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount1',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+    ],
+    name: 'Burn',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount0',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount1',
+        type: 'uint256',
+      },
+    ],
+    name: 'Mint',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount0In',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount1In',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount0Out',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount1Out',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+    ],
+    name: 'Swap',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint112',
+        name: 'reserve0',
+        type: 'uint112',
+      },
+      {
+        indexed: false,
+        internalType: 'uint112',
+        name: 'reserve1',
+        type: 'uint112',
+      },
+    ],
+    name: 'Sync',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'DOMAIN_SEPARATOR',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'MINIMUM_LIQUIDITY',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'PERMIT_TYPEHASH',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+    ],
+    name: 'allowance',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'approve',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+    ],
+    name: 'balanceOf',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+    ],
+    name: 'burn',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'amount0',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount1',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'decimals',
+    outputs: [
+      {
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'factory',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getReserves',
+    outputs: [
+      {
+        internalType: 'uint112',
+        name: 'reserve0',
+        type: 'uint112',
+      },
+      {
+        internalType: 'uint112',
+        name: 'reserve1',
+        type: 'uint112',
+      },
+      {
+        internalType: 'uint32',
+        name: 'blockTimestampLast',
+        type: 'uint32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'initialize',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'kLast',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+    ],
+    name: 'mint',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'liquidity',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'name',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+    ],
+    name: 'nonces',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'deadline',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint8',
+        name: 'v',
+        type: 'uint8',
+      },
+      {
+        internalType: 'bytes32',
+        name: 'r',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32',
+        name: 's',
+        type: 'bytes32',
+      },
+    ],
+    name: 'permit',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'price0CumulativeLast',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'price1CumulativeLast',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+    ],
+    name: 'skim',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'amount0Out',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount1Out',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        internalType: 'bytes',
+        name: 'data',
+        type: 'bytes',
+      },
+    ],
+    name: 'swap',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'symbol',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'sync',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'token0',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'token1',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'transfer',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'from',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'transferFrom',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+]

--- a/frontend/src/utils/formatDisplayAddress.ts
+++ b/frontend/src/utils/formatDisplayAddress.ts
@@ -1,4 +1,4 @@
 import { toChecksumAddress } from 'web3-utils'
 
-const _displayAddr = (addr: string) => `${addr.slice(0, 6)}...${addr.slice(addr.length - 4)}`
-export const displayAddr = (addr: string) => _displayAddr(toChecksumAddress(addr))
+const formatAddr = (addr: string) => `${addr.slice(0, 6)}...${addr.slice(addr.length - 4)}`
+export const displayAddr = (addr: string) => formatAddr(toChecksumAddress(addr))

--- a/frontend/src/utils/formatDisplayAddress.ts
+++ b/frontend/src/utils/formatDisplayAddress.ts
@@ -1,4 +1,4 @@
 import { toChecksumAddress } from 'web3-utils'
 
-const _displayAddr = (addr: string) => addr.slice(0, 6) + '...' + addr.slice(addr.length - 4)
+const _displayAddr = (addr: string) => `${addr.slice(0, 6)}...${addr.slice(addr.length - 4)}`
 export const displayAddr = (addr: string) => _displayAddr(toChecksumAddress(addr))

--- a/frontend/src/utils/price.ts
+++ b/frontend/src/utils/price.ts
@@ -1,4 +1,5 @@
 import CGApi from 'coingecko-api'
+import { HOUR_IN_MS } from '../constants'
 import * as ls from './ttl'
 
 const DEFAULT_PRICES: Record<string, number> = {
@@ -37,7 +38,7 @@ const SYMBOL_TO_QUERY: Record<string, string> = {
 
 export const getCurrentPrice = async (symbol: string) => {
   const cacheKey = `geyser|${symbol}|spot`
-  const TTL = 3600 * 1000 // 60mins
+  const TTL = HOUR_IN_MS
 
   try {
     const query = SYMBOL_TO_QUERY[symbol]

--- a/frontend/src/utils/price.ts
+++ b/frontend/src/utils/price.ts
@@ -1,0 +1,68 @@
+import CGApi from 'coingecko-api'
+import * as ls from './ttl'
+
+const DEFAULT_PRICES: Record<string, number> = {
+  AMPL: 1.0,
+  BTC: 50000.0,
+  WETH: 320,
+  LINK: 5,
+  BAL: 10,
+  LEND: 0.33,
+  COMP: 100,
+  MKR: 350,
+  CRV: 0.5,
+  BZRX: 0.1,
+  YFI: 17000,
+  NMR: 25,
+  USDC: 1,
+  'yDAI+yUSDC+yUSDT+yTUSD': 1.1,
+}
+
+const SYMBOL_TO_QUERY: Record<string, string> = {
+  WBTC: 'wrapped-bitcoin',
+  AMPL: 'ampleforth',
+  WETH: 'ethereum',
+  LINK: 'chainlink',
+  BAL: 'balancer',
+  LEND: 'ethlend',
+  COMP: 'compound-governance-token',
+  MKR: 'maker',
+  CRV: 'curve-dao-token',
+  BZRX: 'bzx-protocol',
+  YFI: 'yearn-finance',
+  NMR: 'numeraire',
+  USDC: 'usd-coin',
+  'yDAI+yUSDC+yUSDT+yTUSD': 'curve-fi-ydai-yusdc-yusdt-ytusd',
+}
+
+export const getCurrentPrice = async (symbol: string) => {
+  const cacheKey = `geyser|${symbol}|spot`
+  const TTL = 3600 * 1000 // 60mins
+
+  try {
+    const query = SYMBOL_TO_QUERY[symbol]
+    if (!query) {
+      throw new Error(`Can't fetch price for ${symbol}`)
+    }
+    const cachedPrice = ls.get(cacheKey)
+    if (cachedPrice) {
+      return cachedPrice as number
+    }
+
+    const client = new CGApi()
+    const reqTimeoutSec = 10
+    const p: any = await Promise.race([
+      client.simple.price({
+        ids: [query],
+        vs_currencies: ['usd'],
+      }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('request timeout')), reqTimeoutSec * 1000)),
+    ])
+    const price = p.data[query].usd
+    ls.set(cacheKey, price, TTL)
+    return price as number
+  } catch (e) {
+    console.error(e)
+    return DEFAULT_PRICES[symbol] || 0
+  }
+}

--- a/frontend/src/utils/stakingToken.ts
+++ b/frontend/src/utils/stakingToken.ts
@@ -1,19 +1,31 @@
 import { BigNumber, Signer } from 'ethers'
 import { formatUnits } from 'ethers/lib/utils'
 import { toChecksumAddress } from 'web3-utils'
+import { StakingToken } from '../constants'
 import { ERC20Balance } from '../sdk'
 import { StakingTokenInfo, TokenComposition } from '../types'
-import { getCurrentPrice } from '../utils/price'
-import { getTokenInfo } from '../utils/tokens'
+import { getCurrentPrice } from './price'
+import { defaultTokenInfo, getTokenInfo } from './token'
 
-export enum StakingToken {
-  MOCK,
-}
+export const defaultStakingTokenInfo = (): StakingTokenInfo => ({
+  ...defaultTokenInfo(),
+  price: 0,
+  totalSupply: 0,
+  marketCap: 0,
+  composition: [],
+})
 
-type StakingTokenFunction = (tokenAddress: string, signer: Signer) => Promise<StakingTokenInfo>
-
-export const STAKING_TOKEN_FUNCTION_MAPPING: Record<StakingToken, StakingTokenFunction> = {
-  [StakingToken.MOCK]: (address: string, signer: Signer) => getMockLPToken(address, signer),
+export const getStakingTokenInfo = async (
+  tokenAddress: string,
+  token: StakingToken,
+  signer: Signer,
+): Promise<StakingTokenInfo> => {
+  switch (token) {
+    case StakingToken.MOCK:
+      return getMockLPToken(tokenAddress, signer)
+    default:
+      throw new Error(`Handler for ${token} not found`)
+  }
 }
 
 const getTokenComposition = async (
@@ -39,7 +51,7 @@ const getTokenComposition = async (
   }
 }
 
-const getMockLPToken = async (tokenAddress: string, signer: Signer): Promise<StakingTokenInfo> => {
+export const getMockLPToken = async (tokenAddress: string, signer: Signer): Promise<StakingTokenInfo> => {
   const price = ((await getCurrentPrice('AMPL')) + (await getCurrentPrice('BAL'))) / 2
   return {
     address: toChecksumAddress(tokenAddress),

--- a/frontend/src/utils/stakingToken.ts
+++ b/frontend/src/utils/stakingToken.ts
@@ -1,9 +1,13 @@
-import { BigNumber, Signer } from 'ethers'
+import { BigNumber, Contract, Signer } from 'ethers'
 import { formatUnits } from 'ethers/lib/utils'
 import { toChecksumAddress } from 'web3-utils'
 import { StakingToken } from '../constants'
 import { ERC20Balance } from '../sdk'
 import { StakingTokenInfo, TokenComposition } from '../types'
+import { BALANCER_BPOOL_V1_ABI } from './abis/BalancerBPoolV1'
+import { BALANCER_CRP_V1_ABI } from './abis/BalancerCRPV1'
+import { MOONISWAP_V1_PAIR_ABI } from './abis/MooniswapV1Pair'
+import { UNISWAP_V2_PAIR_ABI } from './abis/UniswapV2Pair'
 import { getCurrentPrice } from './price'
 import { defaultTokenInfo, getTokenInfo } from './token'
 
@@ -22,7 +26,17 @@ export const getStakingTokenInfo = async (
 ): Promise<StakingTokenInfo> => {
   switch (token) {
     case StakingToken.MOCK:
-      return getMockLPToken(tokenAddress, signer)
+      return getMockLPToken(tokenAddress)
+    case StakingToken.UNISWAP_V2:
+      return getUniswapV2(tokenAddress, signer)
+    case StakingToken.SUSHISWAP:
+      return getSushiswap(tokenAddress, signer)
+    case StakingToken.MOONISWAP_V1:
+      return getMooniswap(tokenAddress, signer)
+    case StakingToken.BALANCER_V1:
+      return getBalancerV1(tokenAddress, signer)
+    case StakingToken.BALANCER_SMART_POOL_V1:
+      return getBalancerSmartPoolV1(tokenAddress, signer)
     default:
       throw new Error(`Handler for ${token} not found`)
   }
@@ -51,7 +65,149 @@ const getTokenComposition = async (
   }
 }
 
-export const getMockLPToken = async (tokenAddress: string, signer: Signer): Promise<StakingTokenInfo> => {
+const getTokenCompositions = async (
+  tokenAddresses: string[],
+  stakingTokenAddress: string,
+  signer: Signer,
+  weights: number[],
+): Promise<TokenComposition[]> =>
+  Promise.all(
+    tokenAddresses.map((token, index) => getTokenComposition(token, stakingTokenAddress, signer, weights[index])),
+  )
+
+const getMarketCap = (composition: TokenComposition[]) => composition.reduce((m, c) => m + c.value, 0)
+
+const uniswapV2Pair = async (
+  tokenAddress: string,
+  signer: Signer,
+  namePrefix: string,
+  symbolPrefix: string,
+): Promise<StakingTokenInfo> => {
+  const address = toChecksumAddress(tokenAddress)
+  const contract = new Contract(address, UNISWAP_V2_PAIR_ABI, signer)
+  const token0Address: string = await contract.token0()
+  const token1Address: string = await contract.token1()
+  const decimals: number = await contract.decimals()
+
+  const totalSupply: BigNumber = await contract.totalSupply()
+
+  const totalSupplyNumber = parseFloat(formatUnits(totalSupply, decimals))
+
+  const tokenCompositions = await getTokenCompositions([token0Address, token1Address], address, signer, [0.5, 0.5])
+  const [token0Symbol, token1Symbol] = tokenCompositions.map((c) => c.symbol)
+  const marketCap = getMarketCap(tokenCompositions)
+
+  return {
+    address: toChecksumAddress(tokenAddress),
+    name: `${namePrefix}-${token0Symbol}-${token1Symbol} Liquidity Token`,
+    symbol: `${symbolPrefix}-${token0Symbol}-${token1Symbol}-V2`,
+    decimals,
+    price: marketCap / totalSupplyNumber,
+    totalSupply: totalSupplyNumber,
+    marketCap,
+    composition: tokenCompositions,
+  }
+}
+
+const getUniswapV2 = async (tokenAddress: string, signer: Signer) =>
+  uniswapV2Pair(tokenAddress, signer, 'UniswapV2', 'UNI')
+
+const getSushiswap = async (tokenAddress: string, signer: Signer) =>
+  uniswapV2Pair(tokenAddress, signer, 'Sushiswap', 'SUSHI')
+
+const getMooniswap = async (tokenAddress: string, signer: Signer): Promise<StakingTokenInfo> => {
+  const address = toChecksumAddress(tokenAddress)
+  const contract = new Contract(address, MOONISWAP_V1_PAIR_ABI, signer)
+  const tokens: [string, string] = await contract.getTokens()
+  const [token0Address, token1Address] = tokens
+  const decimals: number = await contract.decimals()
+  const symbol: string = await contract.symbol()
+  const name: string = await contract.name()
+
+  const totalSupply: BigNumber = await contract.totalSupply()
+
+  const totalSupplyNumber = parseFloat(formatUnits(totalSupply, decimals))
+
+  const tokenCompositions = await getTokenCompositions([token0Address, token1Address], address, signer, [0.5, 0.5])
+  const marketCap = getMarketCap(tokenCompositions)
+
+  return {
+    address,
+    name,
+    symbol,
+    decimals,
+    price: marketCap / totalSupplyNumber,
+    totalSupply: totalSupplyNumber,
+    marketCap,
+    composition: tokenCompositions,
+  }
+}
+
+const getBalancerTokenCompositions = async (address: string, signer: Signer): Promise<TokenComposition[]> => {
+  const contract = new Contract(address, BALANCER_BPOOL_V1_ABI, signer)
+  const tokenAddresses: string[] = await contract.getCurrentTokens()
+  const totalDenormalizedWeight: number = await contract.getTotalDenormalizedWeight()
+  const tokenDenormalizedWeights: number[] = await Promise.all(
+    tokenAddresses.map((token) => contract.getDenormalizedWeight(token)),
+  )
+  const tokenWeights = tokenDenormalizedWeights.map((w) => w / totalDenormalizedWeight)
+
+  return getTokenCompositions(tokenAddresses, address, signer, tokenWeights)
+}
+
+const getBalancerV1 = async (tokenAddress: string, signer: Signer): Promise<StakingTokenInfo> => {
+  const address = toChecksumAddress(tokenAddress)
+  const contract = new Contract(address, BALANCER_BPOOL_V1_ABI, signer)
+
+  const name: string = await contract.name()
+  const symbol: string = await contract.symbol()
+  const decimals: number = await contract.decimals()
+
+  const totalSupply: BigNumber = await contract.totalSupply()
+  const totalSupplyNumber = parseFloat(formatUnits(totalSupply, decimals))
+
+  const tokenCompositions = await getBalancerTokenCompositions(address, signer)
+  const marketCap = getMarketCap(tokenCompositions)
+
+  return {
+    address,
+    decimals,
+    name,
+    symbol,
+    totalSupply: totalSupplyNumber,
+    marketCap,
+    price: marketCap / totalSupplyNumber,
+    composition: tokenCompositions,
+  }
+}
+
+const getBalancerSmartPoolV1 = async (tokenAddress: string, signer: Signer): Promise<StakingTokenInfo> => {
+  const address = toChecksumAddress(tokenAddress)
+  const contract = new Contract(address, BALANCER_CRP_V1_ABI, signer)
+
+  const bPool: string = await contract.bPool()
+  const decimals: number = await contract.decimals()
+  const symbol: string = await contract.symbol()
+  const name: string = await contract.name()
+  const totalSupply: BigNumber = await contract.totalSupply()
+  const totalSupplyNumber = parseFloat(formatUnits(totalSupply, decimals))
+
+  const tokenCompositions = await getBalancerTokenCompositions(bPool, signer)
+  const marketCap = getMarketCap(tokenCompositions)
+
+  return {
+    address,
+    decimals,
+    name,
+    symbol,
+    totalSupply: totalSupplyNumber,
+    marketCap,
+    price: marketCap / totalSupplyNumber,
+    composition: tokenCompositions,
+  }
+}
+
+const getMockLPToken = async (tokenAddress: string): Promise<StakingTokenInfo> => {
   const price = ((await getCurrentPrice('AMPL')) + (await getCurrentPrice('BAL'))) / 2
   return {
     address: toChecksumAddress(tokenAddress),

--- a/frontend/src/utils/stats.ts
+++ b/frontend/src/utils/stats.ts
@@ -1,6 +1,7 @@
 import { BigNumber, Signer } from 'ethers'
 import { toChecksumAddress } from 'web3-utils'
-import { getCurrentVaultReward, getFutureUnlockedRewards, getFutureVaultReward } from '../sdk/stats'
+import { formatUnits } from 'ethers/lib/utils'
+import { getCurrentUnlockedRewards, getCurrentVaultReward, getFutureUnlockedRewards } from '../sdk/stats'
 import { Geyser, GeyserStats, Lock, StakingTokenInfo, TokenInfo, UserStats, Vault, VaultStats } from '../types'
 import { ERC20Balance } from '../sdk'
 import { DAY_IN_SEC, YEAR_IN_SEC } from '../constants'
@@ -11,19 +12,21 @@ const nowInSeconds = () => Math.round(Date.now() / 1000)
 export const defaultUserStats = (): UserStats => ({
   apy: 0,
   currentMultiplier: 0,
-  currentReward: BigNumber.from('0'),
+  currentReward: 0,
 })
 
 export const defaultGeyserStats = (): GeyserStats => ({
   duration: 0,
   totalDeposit: 0,
-  totalRewardsClaimed: BigNumber.from('0'),
+  totalRewardsClaimed: 0,
 })
 
 export const defaultVaultStats = (): VaultStats => ({
   id: '',
-  stakingTokenBalance: BigNumber.from('0'),
-  platformTokenBalance: BigNumber.from('0'),
+  stakingTokenBalance: 0,
+  platformTokenBalance: 0,
+  rewardTokenBalance: 0,
+  currentStake: 0,
 })
 
 const getGeyserDuration = (geyser: Geyser) => {
@@ -37,14 +40,26 @@ const getGeyserDuration = (geyser: Geyser) => {
 
 const getGeyserTotalDeposit = (geyser: Geyser, stakingTokenInfo: StakingTokenInfo) => {
   const { totalStake } = geyser
-  return parseInt(totalStake, 10) * stakingTokenInfo.price
+  const { decimals } = stakingTokenInfo
+  const stakingTokenAmount = parseFloat(formatUnits(totalStake, decimals))
+  return stakingTokenAmount * stakingTokenInfo.price
 }
 
-export const getGeyserStats = async (geyser: Geyser, stakingTokenInfo: StakingTokenInfo): Promise<GeyserStats> => ({
-  duration: getGeyserDuration(geyser),
-  totalDeposit: getGeyserTotalDeposit(geyser, stakingTokenInfo),
-  totalRewardsClaimed: BigNumber.from(geyser.totalRewardsClaimed),
-})
+export const getGeyserStats = async (
+  geyser: Geyser,
+  stakingTokenInfo: StakingTokenInfo,
+  rewardTokenInfo: TokenInfo,
+): Promise<GeyserStats> => {
+  const { totalRewardsClaimed } = geyser
+  const { decimals } = rewardTokenInfo
+  const formattedTotalRewardsClaimed = parseFloat(formatUnits(totalRewardsClaimed, decimals))
+
+  return {
+    duration: getGeyserDuration(geyser),
+    totalDeposit: getGeyserTotalDeposit(geyser, stakingTokenInfo),
+    totalRewardsClaimed: formattedTotalRewardsClaimed,
+  }
+}
 
 const getTotalStakeUnits = (geyser: Geyser, timestamp: number) => {
   const { totalStake, totalStakeUnits: cachedTotalStakeUnits, lastUpdate } = geyser
@@ -61,13 +76,12 @@ const getLockStakeUnits = (lock: Lock, timestamp: number) => {
 }
 
 /**
- * Returns the amount of reward token that will be unlocked between `start` and `end`
+ * Returns the amount of reward token that will be unlocked between now and `end`
  */
-const getPoolDrip = async (geyser: Geyser, start: number, end: number, signer: Signer) => {
-  if (end <= start) return BigNumber.from('0')
+const getPoolDrip = async (geyser: Geyser, end: number, signer: Signer) => {
   const geyserAddress = toChecksumAddress(geyser.id)
   return (await getFutureUnlockedRewards(geyserAddress, end, signer)).sub(
-    await getFutureUnlockedRewards(geyserAddress, start, signer),
+    await getCurrentUnlockedRewards(geyserAddress, signer),
   )
 }
 
@@ -85,19 +99,21 @@ const getUserDrip = async (
 ) => {
   const now = nowInSeconds()
   const afterDuration = now + duration
-  const poolDrip = await getPoolDrip(geyser, now, afterDuration, signer)
+  const poolDrip = await getPoolDrip(geyser, afterDuration, signer)
   const stakeUnitsFromAdditionalStake = additionalStakes.mul(duration)
   const totalStakeUnitsAfterDuration = getTotalStakeUnits(geyser, afterDuration).add(stakeUnitsFromAdditionalStake)
   const lockStakeUnitsAfterDuration = getLockStakeUnits(lock, afterDuration).add(stakeUnitsFromAdditionalStake)
+  if (totalStakeUnitsAfterDuration.isZero()) return BigNumber.from('0')
   return poolDrip.mul(lockStakeUnitsAfterDuration).div(totalStakeUnitsAfterDuration)
 }
 
 const getStakeDrip = async (geyser: Geyser, stake: BigNumber, duration: number, signer: Signer) => {
   const now = nowInSeconds()
   const afterDuration = now + duration
-  const poolDrip = await getPoolDrip(geyser, now, afterDuration, signer)
+  const poolDrip = await getPoolDrip(geyser, afterDuration, signer)
   const stakeUnitsFromStake = stake.mul(duration)
   const totalStakeUnitsAfterDuration = getTotalStakeUnits(geyser, afterDuration).add(stakeUnitsFromStake)
+  if (totalStakeUnitsAfterDuration.isZero()) return BigNumber.from('0')
   return poolDrip.mul(stakeUnitsFromStake).div(totalStakeUnitsAfterDuration)
 }
 
@@ -121,14 +137,15 @@ const getUserAPY = async (
 ) => {
   const { scalingTime } = geyser
   const { amount: stakedAmount } = lock
-  const { price: stakingTokenPrice } = stakingTokenInfo
-  const rewardTokenPrice = await getCurrentPrice(rewardTokenInfo.symbol)
+  const { decimals: stakingTokenDecimals, price: stakingTokenPrice } = stakingTokenInfo
+  const { decimals: rewardTokenDecimals, symbol: rewardTokenSymbol } = rewardTokenInfo
+  const rewardTokenPrice = await getCurrentPrice(rewardTokenSymbol)
   const geyserDuration = getGeyserDuration(geyser)
   const calcPeriod = Math.max(Math.min(geyserDuration, parseInt(scalingTime, 10)), DAY_IN_SEC)
   const userDripAfterPeriod = await getUserDrip(geyser, lock, BigNumber.from('0'), parseInt(scalingTime, 10), signer)
 
-  const inflow = parseInt(stakedAmount, 10) * stakingTokenPrice
-  const outflow = userDripAfterPeriod.mul(rewardTokenPrice).toNumber()
+  const inflow = parseFloat(formatUnits(stakedAmount, stakingTokenDecimals)) * stakingTokenPrice
+  const outflow = parseFloat(formatUnits(userDripAfterPeriod, rewardTokenDecimals)) * rewardTokenPrice
   const periods = YEAR_IN_SEC / calcPeriod
   return calculateAPY(inflow, outflow, periods)
 }
@@ -144,7 +161,9 @@ const getPoolAPY = async (
 ) => {
   const { scalingTime } = geyser
   const { price: stakingTokenPrice } = stakingTokenInfo
-  const rewardTokenPrice = await getCurrentPrice(rewardTokenInfo.symbol)
+  const { decimals: rewardTokenDecimals, symbol: rewardTokenSymbol } = rewardTokenInfo
+  if (!rewardTokenSymbol) return 0
+  const rewardTokenPrice = await getCurrentPrice('AMPL')
 
   const inflow = 20000.0 // avg_deposit: 20,000 USD
 
@@ -152,8 +171,9 @@ const getPoolAPY = async (
   const geyserDuration = getGeyserDuration(geyser)
   const calcPeriod = Math.max(Math.min(geyserDuration, parseInt(scalingTime, 10)), DAY_IN_SEC)
   const stakeDripAfterPeriod = await getStakeDrip(geyser, stake, parseInt(scalingTime, 10), signer)
+  if (stakeDripAfterPeriod.isZero()) return 0
 
-  const outflow = stakeDripAfterPeriod.mul(rewardTokenPrice).toNumber()
+  const outflow = parseFloat(formatUnits(stakeDripAfterPeriod, rewardTokenDecimals)) * rewardTokenPrice
   const periods = YEAR_IN_SEC / calcPeriod
   return calculateAPY(inflow, outflow, periods)
 }
@@ -174,23 +194,19 @@ const getCurrentMultiplier = async (geyser: Geyser, vault: Vault, lock: Lock, si
   const vaultAddress = toChecksumAddress(vault.id)
 
   const now = nowInSeconds()
-  const totalStakeUnits = getTotalStakeUnits(geyser, now)
-  const lockStakeUnits = getLockStakeUnits(lock, now)
-
-  const currentUnlockedRewards = await getFutureUnlockedRewards(geyserAddress, now, signer)
-  const currentRewards = await getFutureVaultReward(vaultAddress, geyserAddress, now, signer)
-  const maxRewards = currentUnlockedRewards.mul(lockStakeUnits).div(totalStakeUnits)
-
   const minMultiplier = 1
   const maxMultiplier = parseInt(scalingCeiling, 10) / parseInt(scalingFloor, 10)
+  const totalStakeUnits = getTotalStakeUnits(geyser, now)
+  const lockStakeUnits = getLockStakeUnits(lock, now)
+  if (totalStakeUnits.isZero()) return minMultiplier
 
-  return (
-    minMultiplier +
-    currentRewards
-      .div(maxRewards)
-      .mul(maxMultiplier - minMultiplier)
-      .toNumber()
-  )
+  const currentUnlockedRewards = await getCurrentUnlockedRewards(geyserAddress, signer)
+  const currentRewards = await getCurrentVaultReward(vaultAddress, geyserAddress, signer)
+  const maxRewards = currentUnlockedRewards.mul(lockStakeUnits).div(totalStakeUnits)
+
+  const fraction = parseFloat(formatUnits(currentRewards.mul(100).div(maxRewards), 2))
+
+  return minMultiplier + fraction * (maxMultiplier - minMultiplier)
 }
 
 export const getUserStats = async (
@@ -209,31 +225,51 @@ export const getUserStats = async (
   }
   const vaultAddress = toChecksumAddress(vault.id)
   const geyserAddress = toChecksumAddress(geyser.id)
-
+  const { decimals: rewardTokenDecimals } = rewardTokenInfo
+  const { amount } = lock
+  const currentRewards = await getCurrentVaultReward(vaultAddress, geyserAddress, signer)
+  const formattedCurrentRewards = parseFloat(formatUnits(currentRewards, rewardTokenDecimals))
+  const apy = BigNumber.from(amount).isZero()
+    ? await getPoolAPY(geyser, stakingTokenInfo, rewardTokenInfo, signer)
+    : await getUserAPY(geyser, lock, stakingTokenInfo, rewardTokenInfo, signer)
   return {
-    apy: await getUserAPY(geyser, lock, stakingTokenInfo, rewardTokenInfo, signer),
+    apy,
     currentMultiplier: await getCurrentMultiplier(geyser, vault, lock, signer),
-    currentReward: await getCurrentVaultReward(vaultAddress, geyserAddress, signer),
+    currentReward: formattedCurrentRewards,
   }
 }
 
 export const getVaultStats = async (
   stakingTokenInfo: StakingTokenInfo,
   platformTokenInfo: TokenInfo,
+  rewardTokenInfo: TokenInfo,
   vault: Vault | null,
+  lock: Lock | null,
   signer: Signer,
 ): Promise<VaultStats> => {
   if (!vault) return defaultVaultStats()
   const vaultAddress = toChecksumAddress(vault.id)
-  const { address: stakingTokenAddress } = stakingTokenInfo
-  const { address: platformToken } = platformTokenInfo
+  const { address: stakingTokenAddress, decimals: stakingTokenDecimals } = stakingTokenInfo
+  const { address: rewardTokenAddress, decimals: rewardTokenDecimals } = rewardTokenInfo
+  const { address: platformToken, decimals: platformTokenDecimals } = platformTokenInfo
   const stakingTokenBalance = await ERC20Balance(toChecksumAddress(stakingTokenAddress), vaultAddress, signer)
+  const rewardTokenBalance = await ERC20Balance(toChecksumAddress(rewardTokenAddress), vaultAddress, signer)
   const platformTokenBalance = platformToken
     ? await ERC20Balance(toChecksumAddress(platformToken), vaultAddress, signer)
     : BigNumber.from('0')
+
+  const formattedStakingTokenBalance = parseFloat(formatUnits(stakingTokenBalance, stakingTokenDecimals))
+  const formattedRewardTokenBalance = parseFloat(formatUnits(rewardTokenBalance, rewardTokenDecimals))
+  const formattedPlatformTokenBalance = parseFloat(formatUnits(platformTokenBalance, platformTokenDecimals))
+
+  const amount = lock ? lock.amount : '0'
+  const currentStake = parseFloat(formatUnits(amount, stakingTokenDecimals))
+
   return {
     id: vaultAddress,
-    stakingTokenBalance,
-    platformTokenBalance,
+    stakingTokenBalance: formattedStakingTokenBalance,
+    platformTokenBalance: formattedPlatformTokenBalance,
+    rewardTokenBalance: formattedRewardTokenBalance,
+    currentStake,
   }
 }

--- a/frontend/src/utils/stats.ts
+++ b/frontend/src/utils/stats.ts
@@ -1,0 +1,239 @@
+import { BigNumber, Signer } from 'ethers'
+import { toChecksumAddress } from 'web3-utils'
+import { getCurrentVaultReward, getFutureUnlockedRewards, getFutureVaultReward } from '../sdk/stats'
+import { Geyser, GeyserStats, Lock, StakingTokenInfo, TokenInfo, UserStats, Vault, VaultStats } from '../types'
+import { ERC20Balance } from '../sdk'
+import { DAY_IN_SEC, YEAR_IN_SEC } from '../constants'
+import { getCurrentPrice } from './price'
+
+const nowInSeconds = () => Math.round(Date.now() / 1000)
+
+export const defaultUserStats = (): UserStats => ({
+  apy: 0,
+  currentMultiplier: 0,
+  currentReward: BigNumber.from('0'),
+})
+
+export const defaultGeyserStats = (): GeyserStats => ({
+  duration: 0,
+  totalDeposit: 0,
+  totalRewardsClaimed: BigNumber.from('0'),
+})
+
+export const defaultVaultStats = (): VaultStats => ({
+  id: '',
+  stakingTokenBalance: BigNumber.from('0'),
+  platformTokenBalance: BigNumber.from('0'),
+})
+
+const getGeyserDuration = (geyser: Geyser) => {
+  const now = nowInSeconds()
+  const { rewardSchedules } = geyser
+  const schedulesEndTime = rewardSchedules.map(
+    (schedule) => parseInt(schedule.start, 10) + parseInt(schedule.duration, 10),
+  )
+  return Math.max(...schedulesEndTime.map((endTime) => endTime - now), 0)
+}
+
+const getGeyserTotalDeposit = (geyser: Geyser, stakingTokenInfo: StakingTokenInfo) => {
+  const { totalStake } = geyser
+  return parseInt(totalStake, 10) * stakingTokenInfo.price
+}
+
+export const getGeyserStats = async (geyser: Geyser, stakingTokenInfo: StakingTokenInfo): Promise<GeyserStats> => ({
+  duration: getGeyserDuration(geyser),
+  totalDeposit: getGeyserTotalDeposit(geyser, stakingTokenInfo),
+  totalRewardsClaimed: BigNumber.from(geyser.totalRewardsClaimed),
+})
+
+const getTotalStakeUnits = (geyser: Geyser, timestamp: number) => {
+  const { totalStake, totalStakeUnits: cachedTotalStakeUnits, lastUpdate } = geyser
+  const lastUpdateTime = parseInt(lastUpdate, 10)
+  const durationSinceLastUpdate = Math.max(timestamp - lastUpdateTime, 0)
+  return BigNumber.from(cachedTotalStakeUnits).add(BigNumber.from(totalStake).mul(durationSinceLastUpdate))
+}
+
+const getLockStakeUnits = (lock: Lock, timestamp: number) => {
+  const { amount, stakeUnits: cachedStakeUnits, lastUpdate } = lock
+  const lastUpdateTime = parseInt(lastUpdate, 10)
+  const durationSinceLastUpdate = Math.max(timestamp - lastUpdateTime, 0)
+  return BigNumber.from(cachedStakeUnits).add(BigNumber.from(amount).mul(durationSinceLastUpdate))
+}
+
+/**
+ * Returns the amount of reward token that will be unlocked between `start` and `end`
+ */
+const getPoolDrip = async (geyser: Geyser, start: number, end: number, signer: Signer) => {
+  if (end <= start) return BigNumber.from('0')
+  const geyserAddress = toChecksumAddress(geyser.id)
+  return (await getFutureUnlockedRewards(geyserAddress, end, signer)).sub(
+    await getFutureUnlockedRewards(geyserAddress, start, signer),
+  )
+}
+
+/**
+ * Returns the amount of reward that the user (vault) will receive after `duration` seconds
+ * from the stakes in `lock` and `additionalStakes`, assuming that the max reward multiplier will be
+ * achieved after `duration` seconds
+ */
+const getUserDrip = async (
+  geyser: Geyser,
+  lock: Lock,
+  additionalStakes: BigNumber,
+  duration: number,
+  signer: Signer,
+) => {
+  const now = nowInSeconds()
+  const afterDuration = now + duration
+  const poolDrip = await getPoolDrip(geyser, now, afterDuration, signer)
+  const stakeUnitsFromAdditionalStake = additionalStakes.mul(duration)
+  const totalStakeUnitsAfterDuration = getTotalStakeUnits(geyser, afterDuration).add(stakeUnitsFromAdditionalStake)
+  const lockStakeUnitsAfterDuration = getLockStakeUnits(lock, afterDuration).add(stakeUnitsFromAdditionalStake)
+  return poolDrip.mul(lockStakeUnitsAfterDuration).div(totalStakeUnitsAfterDuration)
+}
+
+const getStakeDrip = async (geyser: Geyser, stake: BigNumber, duration: number, signer: Signer) => {
+  const now = nowInSeconds()
+  const afterDuration = now + duration
+  const poolDrip = await getPoolDrip(geyser, now, afterDuration, signer)
+  const stakeUnitsFromStake = stake.mul(duration)
+  const totalStakeUnitsAfterDuration = getTotalStakeUnits(geyser, afterDuration).add(stakeUnitsFromStake)
+  return poolDrip.mul(stakeUnitsFromStake).div(totalStakeUnitsAfterDuration)
+}
+
+const calculateAPY = (inflow: number, outflow: number, periods: number) => (1 + outflow / inflow) ** periods - 1
+
+/**
+ * APY = (1 + (outflow / inflow)) ** periods - 1
+ *
+ * inflow = (amount staked by vault * price of the staking token)
+ * outflow = (reward that will be unlocked by vault in the next `scalingTime * price of reward token)
+ * periods = number of `calcPeriod` in a year
+ *
+ * calcPeriod = max(min(geyserDuration, scalingTime), day)
+ */
+const getUserAPY = async (
+  geyser: Geyser,
+  lock: Lock,
+  stakingTokenInfo: StakingTokenInfo,
+  rewardTokenInfo: TokenInfo,
+  signer: Signer,
+) => {
+  const { scalingTime } = geyser
+  const { amount: stakedAmount } = lock
+  const { price: stakingTokenPrice } = stakingTokenInfo
+  const rewardTokenPrice = await getCurrentPrice(rewardTokenInfo.symbol)
+  const geyserDuration = getGeyserDuration(geyser)
+  const calcPeriod = Math.max(Math.min(geyserDuration, parseInt(scalingTime, 10)), DAY_IN_SEC)
+  const userDripAfterPeriod = await getUserDrip(geyser, lock, BigNumber.from('0'), parseInt(scalingTime, 10), signer)
+
+  const inflow = parseInt(stakedAmount, 10) * stakingTokenPrice
+  const outflow = userDripAfterPeriod.mul(rewardTokenPrice).toNumber()
+  const periods = YEAR_IN_SEC / calcPeriod
+  return calculateAPY(inflow, outflow, periods)
+}
+
+/**
+ * Pool APY is the APY for a user who makes an average deposit at the current moment in time
+ */
+const getPoolAPY = async (
+  geyser: Geyser,
+  stakingTokenInfo: StakingTokenInfo,
+  rewardTokenInfo: TokenInfo,
+  signer: Signer,
+) => {
+  const { scalingTime } = geyser
+  const { price: stakingTokenPrice } = stakingTokenInfo
+  const rewardTokenPrice = await getCurrentPrice(rewardTokenInfo.symbol)
+
+  const inflow = 20000.0 // avg_deposit: 20,000 USD
+
+  const stake = BigNumber.from(Math.round(inflow / stakingTokenPrice))
+  const geyserDuration = getGeyserDuration(geyser)
+  const calcPeriod = Math.max(Math.min(geyserDuration, parseInt(scalingTime, 10)), DAY_IN_SEC)
+  const stakeDripAfterPeriod = await getStakeDrip(geyser, stake, parseInt(scalingTime, 10), signer)
+
+  const outflow = stakeDripAfterPeriod.mul(rewardTokenPrice).toNumber()
+  const periods = YEAR_IN_SEC / calcPeriod
+  return calculateAPY(inflow, outflow, periods)
+}
+
+/**
+ * Reward multiplier for the stakes of a vault on a geyser
+ *
+ * The minimum multiplier is 1, and the maximum multiplier is scalingCeiling / scalingFloor
+ *
+ * If the current multiplier were maxed, then the rewards from unstaking all stakes
+ * would be maxRewards = (currentUnlockedRewards * lockStakeUnits / totalStakeUnits)
+ *
+ * The actual current multiplier is then { minMultiplier + currentRewards / maxRewards * (maxMultiplier - minMultiplier) }
+ */
+const getCurrentMultiplier = async (geyser: Geyser, vault: Vault, lock: Lock, signer: Signer) => {
+  const { scalingFloor, scalingCeiling } = geyser
+  const geyserAddress = toChecksumAddress(geyser.id)
+  const vaultAddress = toChecksumAddress(vault.id)
+
+  const now = nowInSeconds()
+  const totalStakeUnits = getTotalStakeUnits(geyser, now)
+  const lockStakeUnits = getLockStakeUnits(lock, now)
+
+  const currentUnlockedRewards = await getFutureUnlockedRewards(geyserAddress, now, signer)
+  const currentRewards = await getFutureVaultReward(vaultAddress, geyserAddress, now, signer)
+  const maxRewards = currentUnlockedRewards.mul(lockStakeUnits).div(totalStakeUnits)
+
+  const minMultiplier = 1
+  const maxMultiplier = parseInt(scalingCeiling, 10) / parseInt(scalingFloor, 10)
+
+  return (
+    minMultiplier +
+    currentRewards
+      .div(maxRewards)
+      .mul(maxMultiplier - minMultiplier)
+      .toNumber()
+  )
+}
+
+export const getUserStats = async (
+  geyser: Geyser,
+  vault: Vault | null,
+  lock: Lock | null,
+  stakingTokenInfo: StakingTokenInfo,
+  rewardTokenInfo: TokenInfo,
+  signer: Signer,
+): Promise<UserStats> => {
+  if (!vault || !lock) {
+    return {
+      ...defaultUserStats(),
+      apy: await getPoolAPY(geyser, stakingTokenInfo, rewardTokenInfo, signer),
+    }
+  }
+  const vaultAddress = toChecksumAddress(vault.id)
+  const geyserAddress = toChecksumAddress(geyser.id)
+
+  return {
+    apy: await getUserAPY(geyser, lock, stakingTokenInfo, rewardTokenInfo, signer),
+    currentMultiplier: await getCurrentMultiplier(geyser, vault, lock, signer),
+    currentReward: await getCurrentVaultReward(vaultAddress, geyserAddress, signer),
+  }
+}
+
+export const getVaultStats = async (
+  stakingTokenInfo: StakingTokenInfo,
+  platformTokenInfo: TokenInfo,
+  vault: Vault | null,
+  signer: Signer,
+): Promise<VaultStats> => {
+  if (!vault) return defaultVaultStats()
+  const vaultAddress = toChecksumAddress(vault.id)
+  const { address: stakingTokenAddress } = stakingTokenInfo
+  const { address: platformToken } = platformTokenInfo
+  const stakingTokenBalance = await ERC20Balance(toChecksumAddress(stakingTokenAddress), vaultAddress, signer)
+  const platformTokenBalance = platformToken
+    ? await ERC20Balance(toChecksumAddress(platformToken), vaultAddress, signer)
+    : BigNumber.from('0')
+  return {
+    id: vaultAddress,
+    stakingTokenBalance,
+    platformTokenBalance,
+  }
+}

--- a/frontend/src/utils/token.ts
+++ b/frontend/src/utils/token.ts
@@ -1,10 +1,9 @@
 import { Signer } from 'ethers'
 import { toChecksumAddress } from 'web3-utils'
 import { ERC20Decimals, ERC20Name, ERC20Symbol } from '../sdk'
-import { StakingTokenInfo, TokenInfo } from '../types'
+import { TokenInfo } from '../types'
 import * as ls from './ttl'
 import { CONST_CACHE_TIME_MS } from '../constants'
-import { StakingToken, STAKING_TOKEN_FUNCTION_MAPPING } from '../config/stakingToken'
 
 export const getTokenInfo = async (
   tokenAddress: string,
@@ -29,25 +28,9 @@ export const getTokenInfo = async (
   return value
 }
 
-export const getStakingTokenInfo = async (
-  tokenAddress: string,
-  token: StakingToken,
-  signer: Signer,
-): Promise<StakingTokenInfo> => {
-  return STAKING_TOKEN_FUNCTION_MAPPING[token](tokenAddress, signer)
-}
-
 export const defaultTokenInfo = (): TokenInfo => ({
   address: '',
   name: '',
   symbol: '',
   decimals: 0,
-})
-
-export const defaultStakingTokenInfo = (): StakingTokenInfo => ({
-  ...defaultTokenInfo(),
-  price: 0,
-  totalSupply: 0,
-  marketCap: 0,
-  composition: [],
 })

--- a/frontend/src/utils/tokens.ts
+++ b/frontend/src/utils/tokens.ts
@@ -1,0 +1,53 @@
+import { Signer } from 'ethers'
+import { toChecksumAddress } from 'web3-utils'
+import { ERC20Decimals, ERC20Name, ERC20Symbol } from '../sdk'
+import { StakingTokenInfo, TokenInfo } from '../types'
+import * as ls from './ttl'
+import { CONST_CACHE_TIME_MS } from '../constants'
+import { StakingToken, STAKING_TOKEN_FUNCTION_MAPPING } from '../config/stakingToken'
+
+export const getTokenInfo = async (
+  tokenAddress: string,
+  signer: Signer,
+  ttl: number = CONST_CACHE_TIME_MS,
+): Promise<TokenInfo> => {
+  const address = toChecksumAddress(tokenAddress)
+  const cacheKey = `${address}|tokenInfo`
+  const cachedValue = ls.get(cacheKey)
+  if (cachedValue) {
+    return cachedValue as TokenInfo
+  }
+
+  const value: TokenInfo = {
+    address,
+    name: await ERC20Name(address, signer),
+    symbol: await ERC20Symbol(address, signer),
+    decimals: await ERC20Decimals(address, signer),
+  }
+
+  ls.set(cacheKey, value, ttl)
+  return value
+}
+
+export const getStakingTokenInfo = async (
+  tokenAddress: string,
+  token: StakingToken,
+  signer: Signer,
+): Promise<StakingTokenInfo> => {
+  return STAKING_TOKEN_FUNCTION_MAPPING[token](tokenAddress, signer)
+}
+
+export const defaultTokenInfo = (): TokenInfo => ({
+  address: '',
+  name: '',
+  symbol: '',
+  decimals: 0,
+})
+
+export const defaultStakingTokenInfo = (): StakingTokenInfo => ({
+  ...defaultTokenInfo(),
+  price: 0,
+  totalSupply: 0,
+  marketCap: 0,
+  composition: [],
+})

--- a/frontend/src/utils/ttl.ts
+++ b/frontend/src/utils/ttl.ts
@@ -1,0 +1,17 @@
+export const set = (key: string, value: any, ttl: number) => {
+  const data = { value, expiresAt: new Date().getTime() + ttl }
+  localStorage.setItem(key, JSON.stringify(data))
+}
+
+export const get = (key: string): any => {
+  const data = localStorage.getItem(key)
+  if (data !== null) {
+    const { value, expiresAt } = JSON.parse(data)
+    if (expiresAt && expiresAt < new Date().getTime()) {
+      localStorage.removeItem(key)
+    } else {
+      return value
+    }
+  }
+  return null
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2431,6 +2431,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/coingecko-api@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/coingecko-api/-/coingecko-api-1.0.0.tgz#1f3373c76034a58248fdaefcf7f2ec32351050ea"
+  integrity sha512-ic7lNZ+3cKvv8XZbnpWap1Il7b8qbdQH/xJIGbPkqer1bReePdFSbUrDo6rNMy3OwDAVLO6ami0VKnwJSzG0ew==
+
 "@types/eslint@^7.2.6":
   version "7.2.12"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.12.tgz#fefaa48a4db2415b621fe315e4baeedde525927e"
@@ -4642,6 +4647,11 @@ coa@^2.0.2:
     "@types/q" "^1.5.1"
     chalk "^2.4.1"
     q "^1.1.2"
+
+coingecko-api@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/coingecko-api/-/coingecko-api-1.0.10.tgz#ac8694d5999f00727fe55f0078ce2917603076b2"
+  integrity sha512-7YLLC85+daxAw5QlBWoHVBVpJRwoPr4HtwanCr8V/WRjoyHTa1Lb9DQAvv4MDJZHiz4no6HGnDQnddtjV35oRA==
 
 collect-v8-coverage@^1.0.0:
   version "1.0.1"

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -87,6 +87,7 @@ task('deploy', 'deploy full set of factory contracts')
     if (mock) {
       const totalSupply = parseUnits('10')
       await deployContract('MockERC20', ethers.getContractFactory, signer, [signer.address, totalSupply])
+      await deployContract('MockBAL', ethers.getContractFactory, signer, [signer.address, totalSupply])
       await deployMockAmpl(signer, ethers.getContractFactory, upgrades.deployProxy)
     }
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -237,7 +237,7 @@ task('fund-geyser', 'fund an instance of Geyser')
     const data = await geyserContract.getGeyserData()
     const { rewardToken: rewardTokenAddress } = data
     const rewardToken = await ethers.getContractAt('MockAmpl', rewardTokenAddress, signer)
-    const amt = BigNumber.from(amount)
+    const amt = parseUnits(amount, 9)
     await rewardToken.approve(geyser, amt)
     await geyserContract.connect(signer).fundGeyser(amt, 10000)
   })

--- a/subgraph/abis/IGeyser.json
+++ b/subgraph/abis/IGeyser.json
@@ -66,12 +66,6 @@
         {
           "indexed": false,
           "internalType": "address",
-          "name": "recipient",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
           "name": "token",
           "type": "address"
         },

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -22,6 +22,7 @@ type Geyser @entity {
   lastUpdate: BigInt!
   rewardSchedules: [RewardSchedule]! @derivedFrom(field: "geyser")
   locks: [Lock]! @derivedFrom(field: "geyser")
+  totalRewardsClaimed: BigInt!
 }
 
 type User @entity {

--- a/subgraph/src/geyser.ts
+++ b/subgraph/src/geyser.ts
@@ -79,6 +79,7 @@ export function handleGeyserCreated(event: GeyserCreated): void {
   entity.scalingTime = geyserData.rewardScaling.time
   entity.status = 'Online'
   entity.bonusTokens = []
+  entity.totalRewardsClaimed = BigInt.fromI32(0)
 
   _updateGeyser(entity, geyserContract, event.block.timestamp)
 }
@@ -149,6 +150,7 @@ export function handleRewardClaimed(event: RewardClaimed): void {
   let entity = ClaimedReward.load(id)
   if (entity == null) {
     entity = new ClaimedReward(id)
+    entity.amount = BigInt.fromI32(0)
   }
 
   entity.vault = event.params.vault.toHex()
@@ -156,6 +158,9 @@ export function handleRewardClaimed(event: RewardClaimed): void {
   entity.amount = entity.amount.plus(event.params.amount)
   entity.lastUpdate = event.block.timestamp
 
+  let geyser = Geyser.load(event.address.toHex()) as Geyser
+  geyser.totalRewardsClaimed = geyser.totalRewardsClaimed.plus(event.params.amount)
+  geyser.save()
   updateGeyser(event.address, event.block.timestamp)
 
   entity.save()

--- a/subgraph/subgraph.template.yaml
+++ b/subgraph/subgraph.template.yaml
@@ -90,7 +90,7 @@ templates:
           handler: handleStaked
         - event: Unstaked(address,uint256)
           handler: handleUnstaked
-        - event: RewardClaimed(address,address,address,uint256)
+        - event: RewardClaimed(address,address,uint256)
           handler: handleRewardClaimed
   - kind: ethereum/contract
     name: PowerSwitchTemplate


### PR DESCRIPTION
## Description

Add stats context that will provide props to get user / vault / geyser statistics.

### Stats
All stats that require accounting math computed in the frontend was ported from the [V1 ui](https://github.com/hyplabs/gesyer-v1-ui/blob/main/src/lib/cvtd.js), using the equivalent contract functions and subgraph fields from V2.

#### Subgraph
Added a `totalRewardsClaimed` field in the `Geyser` entity of the subgraph that keeps track of the total rewards claimed by users. Also fixed the `RewardClaimed` event handler.

### Coingecko API
The coingecko API was integrated to be able to query ERC20 token prices. The code is almost identical to the [V1 code](https://github.com/hyplabs/gesyer-v1-ui/blob/main/src/lib/price.js). This is required for computing stats such as APY, total deposits, etc. which require the price in USD of the staking / reward tokens.

### Staking token list
Staking tokens (i.e. LP tokens like UNI-V2) are not exactly like vanilla ERC20, e.g. they have specific price calculation that is not available from the coingecko api. We port over the [staking tokens from V1](https://github.com/hyplabs/gesyer-v1-ui/blob/main/src/lib/StakingToken.js), but they require the app to be connected to the mainnet. As a result, they cannot be readily tested within the app, but testing was done via `console.log`. For the context of the app, a mock staking token was created and integrated to mimic some but not all the of the behaviour of a typical staking token.

### Geyser config list
We want to show only select geysers on the UI, so a list of geysers is maintained, and the geyser data is queried from the subgraph using the addresses listed on the geyser config list.