### PR TITLE
fix contract unstake bug and add more stats functions

### DIFF
--- a/contracts/Geyser.sol
+++ b/contracts/Geyser.sol
@@ -891,8 +891,14 @@ contract Geyser is IGeyser, Powered, OwnableUpgradeable {
             // some stakes have been completely or partially unstaked
             // delete fully unstaked stakes
             while (vaultData.stakes.length > out.newStakesCount) vaultData.stakes.pop();
-            // update partially unstaked stake
-            vaultData.stakes[out.newStakesCount.sub(1)].amount = out.lastStakeAmount;
+
+            // note: if out.lastStakeAmount == 0, it means that the amount unstaked was exactly the amount
+            // staked in vaultData.stakes[vaultData.stakes.length.sub(1)],
+            // so there is no need to update the stake in vaultData.stakes[vaultData.stakes.length.sub(2)]
+            if (out.lastStakeAmount > 0) {
+                // update partially unstaked stake
+                vaultData.stakes[out.newStakesCount.sub(1)].amount = out.lastStakeAmount;
+            }
         }
 
         // update cached stake totals

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react'
 import styled from 'styled-components/macro'
-import { toChecksumAddress } from 'web3-utils'
 import { GeyserContext } from '../context/GeyserContext'
 import { VaultContext } from '../context/VaultContext'
 import { displayAddr } from '../utils/formatDisplayAddress'
@@ -9,7 +8,7 @@ import { HeaderWalletButton } from './HeaderWalletButton'
 interface Props {}
 
 export const Header: React.FC<Props> = () => {
-  const { geysers, selectGeyserById, geyserAddressToName } = useContext(GeyserContext)
+  const { geysers, selectGeyserById, formatGeyserAddress } = useContext(GeyserContext)
   const { vaults, selectVaultById } = useContext(VaultContext)
 
   const handleSelectGeyser = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -30,7 +29,7 @@ export const Header: React.FC<Props> = () => {
             {geysers.map((geyser) => (
               <option key={geyser.id} value={geyser.id}>
                 {' '}
-                {geyserAddressToName.get(toChecksumAddress(geyser.id))}{' '}
+                {formatGeyserAddress(geyser.id)}{' '}
               </option>
             ))}
           </Select>
@@ -58,14 +57,9 @@ export const Header: React.FC<Props> = () => {
 
 interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
 
-const Select: React.FC<SelectProps> = (props) => {
-  const { children } = props
-  return (
-    <DropDownSelect {...props} className="rounded-2xl">
-      {children}
-    </DropDownSelect>
-  )
-}
+const Select: React.FC<SelectProps> = (props) => (
+  <DropDownSelect {...props} className="rounded-2xl" />
+)
 
 const Container = styled.div`
   height: fit-content;

--- a/frontend/src/config/geyser.ts
+++ b/frontend/src/config/geyser.ts
@@ -1,10 +1,21 @@
 import { StakingToken } from '../constants'
 import { GeyserConfig } from '../types'
 
+/**
+ *
+ * `address` should be the actual address to which the geyser contract was deployed
+ *
+ */
 const mockGeyserConfigs: GeyserConfig[] = [
   {
     name: 'Trinity V1 (Balancer BTC-ETH-AMPL)',
-    address: '0x0dcd1bf9a1b36ce34237eeafef220932846bcd82',
+    address: '0x0000000000000000000000000000000000000000',
+    stakingToken: StakingToken.MOCK,
+    platformTokenConfigs: [],
+  },
+  {
+    name: 'Beehive V3 (Uniswap ETH-AMPL)',
+    address: '0x0000000000000000000000000000000000000000',
     stakingToken: StakingToken.MOCK,
     platformTokenConfigs: [],
   },

--- a/frontend/src/config/geyser.ts
+++ b/frontend/src/config/geyser.ts
@@ -1,4 +1,4 @@
-import { StakingToken } from '../constants'
+import { RewardToken, StakingToken } from '../constants'
 import { GeyserConfig } from '../types'
 
 /**
@@ -11,12 +11,14 @@ const mockGeyserConfigs: GeyserConfig[] = [
     name: 'Trinity V1 (Balancer BTC-ETH-AMPL)',
     address: '0x0000000000000000000000000000000000000000',
     stakingToken: StakingToken.MOCK,
+    rewardToken: RewardToken.MOCK,
     platformTokenConfigs: [],
   },
   {
     name: 'Beehive V3 (Uniswap ETH-AMPL)',
     address: '0x0000000000000000000000000000000000000000',
     stakingToken: StakingToken.MOCK,
+    rewardToken: RewardToken.MOCK,
     platformTokenConfigs: [],
   },
 ]
@@ -26,6 +28,7 @@ const mainnetGeyserConfigs: GeyserConfig[] = [
     name: 'Pescadero V1 (Sushiswap ETH-AMPL)',
     address: '0x0000000000000000000000000000000000000000',
     stakingToken: StakingToken.SUSHISWAP,
+    rewardToken: RewardToken.AMPL,
     platformTokenConfigs: [],
     // staking token / pool address: 0xCb2286d9471cc185281c4f763d34A962ED212962
   },
@@ -33,6 +36,7 @@ const mainnetGeyserConfigs: GeyserConfig[] = [
     name: 'Beehive V3 (Uniswap ETH-AMPL)',
     address: '0x0000000000000000000000000000000000000000',
     stakingToken: StakingToken.UNISWAP_V2,
+    rewardToken: RewardToken.AMPL,
     platformTokenConfigs: [],
     // staking token / pool address: 0xc5be99A02C6857f9Eac67BbCE58DF5572498F40c
   },
@@ -40,6 +44,7 @@ const mainnetGeyserConfigs: GeyserConfig[] = [
     name: 'Trinity V1 (Balancer BTC-ETH-AMPL)',
     address: '0x0000000000000000000000000000000000000000',
     stakingToken: StakingToken.BALANCER_V1,
+    rewardToken: RewardToken.AMPL,
     platformTokenConfigs: [
       {
         address: '0xba100000625a3754423978a60c9317c58a424e3d',
@@ -52,6 +57,7 @@ const mainnetGeyserConfigs: GeyserConfig[] = [
     name: 'Old Faithful V1 (Balancer AMPL-USDC)',
     address: '0x0000000000000000000000000000000000000000',
     stakingToken: StakingToken.BALANCER_SMART_POOL_V1,
+    rewardToken: RewardToken.AMPL,
     platformTokenConfigs: [
       {
         address: '0xba100000625a3754423978a60c9317c58a424e3d',

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,17 +1,23 @@
 const MS_PER_SEC = 1000
 
-export const HOUR_IN_SEC = 3600
+export const MIN_IN_SEC = 60
+export const HOUR_IN_SEC = 60 * MIN_IN_SEC
 export const DAY_IN_SEC = 24 * HOUR_IN_SEC
 export const YEAR_IN_SEC = 365 * DAY_IN_SEC
 
+export const MIN_IN_MS = MIN_IN_SEC * MS_PER_SEC
 export const HOUR_IN_MS = HOUR_IN_SEC * MS_PER_SEC
 export const DAY_IN_MS = DAY_IN_SEC * MS_PER_SEC
 export const YEAR_IN_MS = YEAR_IN_SEC * MS_PER_SEC
 
+// polling interval for querying subgraph
 export const POLL_INTERVAL = 5 * MS_PER_SEC
 
 // pseudo permanent cache time
 export const CONST_CACHE_TIME_MS = YEAR_IN_MS
+
+// geyser stats cache time
+export const GEYSER_STATS_CACHE_TIME_MS = MIN_IN_SEC
 
 export const MOCK_ERC_20_ADDRESS = '0x0165878A594ca255338adfa4d48449f69242Eb8F'
 

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -32,3 +32,18 @@ export enum StakingToken {
   BALANCER_V1,
   BALANCER_SMART_POOL_V1,
 }
+
+// Reward tokens
+export enum RewardToken {
+  // for testing
+  MOCK,
+
+  // for mainnet
+  AMPL,
+}
+
+// ufragments deploy block number
+export const UFRG_INIT_BLOCK = 7947823
+
+export const AMPL_LAUNCH_DATE = 1561687200
+export const INITIAL_SUPPLY = 50000000

--- a/frontend/src/context/GeyserContext.tsx
+++ b/frontend/src/context/GeyserContext.tsx
@@ -3,12 +3,13 @@ import { createContext, useContext, useEffect, useState } from 'react'
 import { toChecksumAddress } from 'web3-utils'
 import { LoadingSpinner } from '../components/LoadingSpinner'
 import { GET_GEYSERS } from '../queries/geyser'
-import { Geyser, StakingTokenInfo, TokenInfo, GeyserConfig } from '../types'
+import { Geyser, StakingTokenInfo, TokenInfo, GeyserConfig, RewardTokenInfo } from '../types'
 import Web3Context from './Web3Context'
 import { POLL_INTERVAL } from '../constants'
-import { defaultTokenInfo, getTokenInfo } from '../utils/token'
+import {  getTokenInfo } from '../utils/token'
 import { geyserConfigs } from '../config/geyser'
 import { defaultStakingTokenInfo, getStakingTokenInfo } from '../utils/stakingToken'
+import { defaultRewardTokenInfo, getRewardTokenInfo } from '../utils/rewardToken'
 
 export const GeyserContext = createContext<{
   geysers: Geyser[]
@@ -16,7 +17,7 @@ export const GeyserContext = createContext<{
   selectGeyser: (geyser: Geyser) => void
   selectGeyserById: (id: string) => void
   stakingTokenInfo: StakingTokenInfo
-  rewardTokenInfo: TokenInfo
+  rewardTokenInfo: RewardTokenInfo
   platformTokenInfos: TokenInfo[]
   formatGeyserAddress: (id: string) => string
   selectedGeyserConfig: GeyserConfig | null
@@ -26,7 +27,7 @@ export const GeyserContext = createContext<{
   selectGeyser: () => {},
   selectGeyserById: () => {},
   stakingTokenInfo: defaultStakingTokenInfo(),
-  rewardTokenInfo: defaultTokenInfo(),
+  rewardTokenInfo: defaultRewardTokenInfo(),
   platformTokenInfos: [],
   formatGeyserAddress: () => '',
   selectedGeyserConfig: null,
@@ -42,7 +43,7 @@ export const GeyserContextProvider: React.FC = ({ children }) => {
   const [selectedGeyser, setSelectedGeyser] = useState<Geyser | null>(null)
   const [selectedGeyserConfig, setSelectedGeyserConfig] = useState<GeyserConfig | null>(null)
   const [platformTokenInfos, setPlatformTokenInfos] = useState<TokenInfo[]>([])
-  const [rewardTokenInfo, setRewardTokenInfo] = useState<TokenInfo>(defaultTokenInfo())
+  const [rewardTokenInfo, setRewardTokenInfo] = useState<RewardTokenInfo>(defaultRewardTokenInfo())
   const [geyserAddressToName] = useState<Map<string, string>>(new Map(geyserConfigs.map(geyser => [toChecksumAddress(geyser.address), geyser.name])))
 
   const [stakingTokenInfo, setStakingTokenInfo] = useState<StakingTokenInfo>(defaultStakingTokenInfo())
@@ -57,7 +58,12 @@ export const GeyserContextProvider: React.FC = ({ children }) => {
   }, [])
 
   useEffect(() => {
-    if (geyserData && geyserData.geysers) setGeysers(geyserData.geysers as Geyser[])
+    if (geyserData && geyserData.geysers) {
+      const currentGeysers = [...geyserData.geysers] as Geyser[]
+      const ids = geyserConfigs.map(geyser => geyser.address.toLowerCase())
+      currentGeysers.sort((a, b) => ids.indexOf(a.id) - ids.indexOf(b.id))
+      setGeysers(currentGeysers)
+    }
   }, [geyserData])
 
   useEffect(() => {
@@ -71,7 +77,7 @@ export const GeyserContextProvider: React.FC = ({ children }) => {
             throw new Error(`Geyser config not found for geyser at ${geyserAddress}`)
           }
           const newStakingTokenInfo = await getStakingTokenInfo(selectedGeyser.stakingToken, geyserConfig.stakingToken, signer)
-          const newRewardTokenInfo = await getTokenInfo(selectedGeyser.rewardToken, signer)
+          const newRewardTokenInfo = await getRewardTokenInfo(selectedGeyser.rewardToken, geyserConfig.rewardToken, signer)
           const { platformTokenConfigs } = geyserConfig
           const newPlatformTokenInfos = await Promise.all(platformTokenConfigs.map(({ address }) => getTokenInfo(address, signer)))
           if (mounted) {

--- a/frontend/src/context/GeyserContext.tsx
+++ b/frontend/src/context/GeyserContext.tsx
@@ -18,7 +18,7 @@ export const GeyserContext = createContext<{
   stakingTokenInfo: StakingTokenInfo
   rewardTokenInfo: TokenInfo
   platformTokenInfos: TokenInfo[]
-  geyserAddressToName: Map<string, string>
+  formatGeyserAddress: (id: string) => string
   selectedGeyserConfig: GeyserConfig | null
 }>({
   geysers: [],
@@ -28,7 +28,7 @@ export const GeyserContext = createContext<{
   stakingTokenInfo: defaultStakingTokenInfo(),
   rewardTokenInfo: defaultTokenInfo(),
   platformTokenInfos: [],
-  geyserAddressToName: new Map<string, string>(),
+  formatGeyserAddress: () => '',
   selectedGeyserConfig: null,
 })
 
@@ -49,6 +49,7 @@ export const GeyserContextProvider: React.FC = ({ children }) => {
 
   const selectGeyser = (geyser: Geyser) => setSelectedGeyser(geyser)
   const selectGeyserById = (id: string) => setSelectedGeyser(geysers.find(geyser => toChecksumAddress(geyser.id) === toChecksumAddress(id)) || selectedGeyser)
+  const formatGeyserAddress = (id: string) => geyserAddressToName.get(toChecksumAddress(id)) || ''
 
   useEffect(() => {
     const ids = geyserConfigs.map(geyser => geyser.address.toLowerCase())
@@ -107,7 +108,7 @@ export const GeyserContextProvider: React.FC = ({ children }) => {
         stakingTokenInfo,
         rewardTokenInfo,
         platformTokenInfos,
-        geyserAddressToName,
+        formatGeyserAddress,
         selectedGeyserConfig,
       }}
     >

--- a/frontend/src/context/StatsContext.tsx
+++ b/frontend/src/context/StatsContext.tsx
@@ -30,7 +30,7 @@ export const StatsContextProvider: React.FC = ({ children }) => {
   const [geyserStats, setGeyserStats] = useState<GeyserStats>(defaultGeyserStats())
   const [vaultStats, setVaultStats] = useState<VaultStats>(defaultVaultStats())
 
-  const { signer } = useContext(Web3Context)
+  const { signer, defaultProvider } = useContext(Web3Context)
   const { selectedGeyser, rewardTokenInfo, stakingTokenInfo, platformTokenInfos } = useContext(GeyserContext)
   const { selectedVault, currentLock } = useContext(VaultContext)
 
@@ -67,10 +67,10 @@ export const StatsContextProvider: React.FC = ({ children }) => {
     let mounted = true
     ;(async () => {
       try {
-        if (signer && selectedGeyser) {
+        if (selectedGeyser && stakingTokenInfo.address && rewardTokenInfo.address) {
           const newGeyserStats = await getGeyserStats(selectedGeyser, stakingTokenInfo, rewardTokenInfo)
-          const newUserStats = await getUserStats(selectedGeyser, selectedVault, currentLock, stakingTokenInfo, rewardTokenInfo, signer)
-          const newVaultStats = await getVaultStats(stakingTokenInfo, platformTokenInfos, rewardTokenInfo, selectedVault, currentLock, signer)
+          const newUserStats = await getUserStats(selectedGeyser, selectedVault, currentLock, stakingTokenInfo, rewardTokenInfo, signer || defaultProvider)
+          const newVaultStats = await getVaultStats(stakingTokenInfo, platformTokenInfos, rewardTokenInfo, selectedVault, currentLock, signer || defaultProvider)
           if (mounted) {
             setGeyserStats(newGeyserStats)
             setUserStats(newUserStats)
@@ -82,7 +82,7 @@ export const StatsContextProvider: React.FC = ({ children }) => {
       }
     })()
     return () => { mounted = false }
-  }, [signer, selectedGeyser, selectedVault, currentLock])
+  }, [selectedGeyser, selectedVault, currentLock, stakingTokenInfo.address, rewardTokenInfo.address])
 
   return (
     <StatsContext.Provider

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -29,9 +29,12 @@ export const WalletContextProvider: React.FC = ({ children }) => {
       }
     }
     return BigNumber.from('0')
-  }, [selectedGeyser, signer])
+  }, [selectedGeyser?.stakingToken, signer])
 
-  const refreshWalletAmount = () => getWalletAmount()
+  const refreshWalletAmount = async () => {
+    const balance = await getWalletAmount()
+    setWalletAmount(balance)
+  }
 
   useEffect(() => {
     // `mounted` is a workaround for the warning saying that a state update on an unmounted

--- a/frontend/src/context/Web3Context.tsx
+++ b/frontend/src/context/Web3Context.tsx
@@ -1,15 +1,17 @@
 import { API, Wallet } from 'bnc-onboard/dist/src/interfaces'
 import Onboard from 'bnc-onboard'
 import React, { createContext, useCallback, useEffect, useState } from 'react'
-import { ethers, Signer } from 'ethers'
+import { providers, Signer } from 'ethers'
+import { getDefaultProvider } from '../utils/eth'
 
-class Provider extends ethers.providers.Web3Provider {}
+class Provider extends providers.Web3Provider {}
 
 const Web3Context = createContext<{
   address?: string
   wallet: Wallet | null
   onboard?: API
   provider: Provider | null
+  defaultProvider: providers.Provider
   signer?: Signer
   selectWallet: () => Promise<boolean>
   ready: boolean
@@ -18,6 +20,7 @@ const Web3Context = createContext<{
   ready: false,
   wallet: null,
   provider: null,
+  defaultProvider: getDefaultProvider(),
 })
 
 interface Subscriptions {
@@ -40,6 +43,7 @@ const Web3Provider: React.FC = ({ children }) => {
   const [wallet, setWallet] = useState<Wallet | null>(null)
   const [onboard, setOnboard] = useState<API>()
   const [provider, setProvider] = useState<Provider | null>(null)
+  const [defaultProvider] = useState<providers.Provider>(getDefaultProvider())
   const [signer, setSigner] = useState<Signer>()
   const [ready, setReady] = useState(false)
 
@@ -98,6 +102,7 @@ const Web3Provider: React.FC = ({ children }) => {
         signer,
         selectWallet,
         ready,
+        defaultProvider,
       }}
     >
       {children}

--- a/frontend/src/queries/geyser.ts
+++ b/frontend/src/queries/geyser.ts
@@ -17,8 +17,8 @@ export const GET_GEYSERS = gql`
         id
         duration
         start
+        rewardAmount
       }
-      totalRewardsClaimed
       lastUpdate
     }
   }

--- a/frontend/src/sdk/stats.ts
+++ b/frontend/src/sdk/stats.ts
@@ -1,43 +1,60 @@
-import { BigNumber, BigNumberish, Contract, Signer } from 'ethers'
+import { BigNumber, BigNumberish, Contract, providers, Signer } from 'ethers'
 import { loadNetworkConfig } from './utils'
 
 async function _execGeyserFunction<T>(
   geyserAddress: string,
-  signer: Signer,
+  signerOrProvider: Signer | providers.Provider,
   fnc: string,
   args: any[] = [],
 ): Promise<T> {
-  const config = await loadNetworkConfig(signer)
-  const geyser = new Contract(geyserAddress, config.GeyserTemplate.abi, signer)
+  const config = await loadNetworkConfig(signerOrProvider)
+  const geyser = new Contract(geyserAddress, config.GeyserTemplate.abi, signerOrProvider)
   return geyser[fnc](...args) as Promise<T>
 }
 
-export const getCurrentVaultReward = async (vaultAddress: string, geyserAddress: string, signer: Signer) => {
-  return _execGeyserFunction<BigNumber>(geyserAddress, signer, 'getCurrentVaultReward', [vaultAddress])
+export const getCurrentVaultReward = async (
+  vaultAddress: string,
+  geyserAddress: string,
+  signerOrProvider: Signer | providers.Provider,
+) => {
+  return _execGeyserFunction<BigNumber>(geyserAddress, signerOrProvider, 'getCurrentVaultReward', [vaultAddress])
 }
 
 export const getFutureVaultReward = async (
   vaultAddress: string,
   geyserAddress: string,
   timestamp: number,
-  signer: Signer,
+  signerOrProvider: Signer | providers.Provider,
 ) => {
-  return _execGeyserFunction<BigNumber>(geyserAddress, signer, 'getFutureVaultReward', [vaultAddress, timestamp])
+  return _execGeyserFunction<BigNumber>(geyserAddress, signerOrProvider, 'getFutureVaultReward', [
+    vaultAddress,
+    timestamp,
+  ])
 }
 
-export const getCurrentUnlockedRewards = async (geyserAddress: string, signer: Signer) => {
-  return _execGeyserFunction<BigNumber>(geyserAddress, signer, 'getCurrentUnlockedRewards')
+export const getCurrentUnlockedRewards = async (
+  geyserAddress: string,
+  signerOrProvider: Signer | providers.Provider,
+) => {
+  return _execGeyserFunction<BigNumber>(geyserAddress, signerOrProvider, 'getCurrentUnlockedRewards')
 }
 
-export const getFutureUnlockedRewards = async (geyserAddress: string, timestamp: number, signer: Signer) => {
-  return _execGeyserFunction<BigNumber>(geyserAddress, signer, 'getFutureUnlockedRewards', [timestamp])
+export const getFutureUnlockedRewards = async (
+  geyserAddress: string,
+  timestamp: number,
+  signerOrProvider: Signer | providers.Provider,
+) => {
+  return _execGeyserFunction<BigNumber>(geyserAddress, signerOrProvider, 'getFutureUnlockedRewards', [timestamp])
 }
 
 export const getCurrentStakeReward = async (
   vaultAddress: string,
   geyserAddress: string,
   amount: BigNumberish,
-  signer: Signer,
+  signerOrProvider: Signer | providers.Provider,
 ) => {
-  return _execGeyserFunction<BigNumber>(geyserAddress, signer, 'getCurrentStakeReward', [vaultAddress, amount])
+  return _execGeyserFunction<BigNumber>(geyserAddress, signerOrProvider, 'getCurrentStakeReward', [
+    vaultAddress,
+    amount,
+  ])
 }

--- a/frontend/src/sdk/tokens.ts
+++ b/frontend/src/sdk/tokens.ts
@@ -1,28 +1,32 @@
-import { BigNumber, Contract, Signer } from 'ethers'
-import { parseUnits } from 'ethers/lib/utils'
+import { BigNumber, Contract, providers, Signer } from 'ethers'
 import { ERC20_ABI } from './abis'
 
-function _execTokenFunction<T>(tokenAddress: string, signer: Signer, fnc: string, args: any[] = []): Promise<T> {
-  const token = new Contract(tokenAddress, ERC20_ABI, signer)
+function _execTokenFunction<T>(
+  tokenAddress: string,
+  signerOrProvider: Signer | providers.Provider,
+  fnc: string,
+  args: any[] = [],
+): Promise<T> {
+  const token = new Contract(tokenAddress, ERC20_ABI, signerOrProvider)
   return token[fnc](...args) as Promise<T>
 }
 
-export const ERC20Decimals = async (tokenAddress: string, signer: Signer) => {
-  return _execTokenFunction<number>(tokenAddress, signer, 'decimals')
+export const ERC20Decimals = async (tokenAddress: string, signerOrProvider: Signer | providers.Provider) => {
+  return _execTokenFunction<number>(tokenAddress, signerOrProvider, 'decimals')
 }
 
-export const ERC20Name = async (tokenAddress: string, signer: Signer) => {
-  return _execTokenFunction<string>(tokenAddress, signer, 'name')
+export const ERC20Name = async (tokenAddress: string, signerOrProvider: Signer | providers.Provider) => {
+  return _execTokenFunction<string>(tokenAddress, signerOrProvider, 'name')
 }
 
-export const ERC20Symbol = async (tokenAddress: string, signer: Signer) => {
-  return _execTokenFunction<string>(tokenAddress, signer, 'symbol')
+export const ERC20Symbol = async (tokenAddress: string, signerOrProvider: Signer | providers.Provider) => {
+  return _execTokenFunction<string>(tokenAddress, signerOrProvider, 'symbol')
 }
 
-export const ERC20Balance = async (tokenAddress: string, holderAddress: string, signer: Signer) => {
-  return _execTokenFunction<BigNumber>(tokenAddress, signer, 'balanceOf', [holderAddress])
-}
-
-export const parseUnitsWithDecimals = async (value: string, tokenAddress: string, signer: Signer) => {
-  return parseUnits(value, await ERC20Decimals(tokenAddress, signer))
+export const ERC20Balance = async (
+  tokenAddress: string,
+  holderAddress: string,
+  signerOrProvider: Signer | providers.Provider,
+) => {
+  return _execTokenFunction<BigNumber>(tokenAddress, signerOrProvider, 'balanceOf', [holderAddress])
 }

--- a/frontend/src/sdk/utils.ts
+++ b/frontend/src/sdk/utils.ts
@@ -1,12 +1,14 @@
 import { TypedDataField } from '@ethersproject/abstract-signer'
-import { BigNumberish, Contract, Signer, Wallet } from 'ethers'
+import { BigNumberish, Contract, providers, Signer, Wallet } from 'ethers'
 import { splitSignature } from 'ethers/lib/utils'
 import mainnetConfig from './deployments/mainnet/factories-latest.json'
 import goerliConfig from './deployments/goerli/factories-latest.json'
 import localhostConfig from './deployments/localhost/factories-latest.json'
 
-export const loadNetworkConfig = async (signer: Signer) => {
-  const network = await signer.provider?.getNetwork()
+export const loadNetworkConfig = async (signerOrProvider: Signer | providers.Provider) => {
+  const network = await (Signer.isSigner(signerOrProvider)
+    ? signerOrProvider.provider?.getNetwork()
+    : signerOrProvider.getNetwork())
 
   switch (network?.name) {
     case 'mainnet':

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,4 +1,5 @@
-import { StakingToken } from './constants'
+import { Contract } from 'ethers'
+import { RewardToken, StakingToken } from './constants'
 
 type ClaimedReward = {
   id: string
@@ -24,6 +25,7 @@ export type RewardSchedule = {
   id: string
   duration: string
   start: string
+  rewardAmount: string
 }
 
 export type Geyser = {
@@ -38,7 +40,6 @@ export type Geyser = {
   scalingTime: string
   unlockedReward: string
   rewardSchedules: RewardSchedule[]
-  totalRewardsClaimed: string
   lastUpdate: string
 }
 
@@ -58,11 +59,7 @@ export type TokenInfo = {
   decimals: number
 }
 
-export type TokenComposition = {
-  address: string
-  name: string
-  symbol: string
-  decimals: number
+export type TokenComposition = TokenInfo & {
   balance: number
   value: number
   weight: number
@@ -75,10 +72,14 @@ export type StakingTokenInfo = TokenInfo & {
   composition: TokenComposition[]
 }
 
+export type RewardTokenInfo = TokenInfo & {
+  getTotalRewards: (rewardSchedules: RewardSchedule[]) => Promise<number>
+}
+
 export type GeyserStats = {
   duration: number
   totalDeposit: number
-  totalRewardsClaimed: number
+  totalRewards: number
 }
 
 export type VaultStats = {
@@ -99,10 +100,17 @@ export type GeyserConfig = {
   name: string
   address: string
   stakingToken: StakingToken
+  rewardToken: RewardToken
   platformTokenConfigs: PlatformTokenConfig[]
 }
 
 export type PlatformTokenConfig = {
   address: string
   claimLink?: string
+}
+
+export type SupplyInfo = {
+  timestamp: number
+  supply: number
+  epoch: number
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,4 +1,4 @@
-import { Contract } from 'ethers'
+import { providers, Signer } from 'ethers'
 import { RewardToken, StakingToken } from './constants'
 
 type ClaimedReward = {
@@ -114,3 +114,5 @@ export type SupplyInfo = {
   supply: number
   epoch: number
 }
+
+export type SignerOrProvider = Signer | providers.Provider

--- a/frontend/src/utils/abis/UFragments.ts
+++ b/frontend/src/utils/abis/UFragments.ts
@@ -1,0 +1,527 @@
+export const UFRAGMENTS_ABI = [
+  {
+    constant: true,
+    inputs: [],
+    name: 'name',
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'decimals',
+    outputs: [
+      {
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'rebasePaused',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [],
+    name: 'renounceOwnership',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'tokenPaused',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'owner',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'monetaryPolicy',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'isOwner',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'symbol',
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'transferOwnership',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        name: 'epoch',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'totalSupply',
+        type: 'uint256',
+      },
+    ],
+    name: 'LogRebase',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        name: 'paused',
+        type: 'bool',
+      },
+    ],
+    name: 'LogRebasePaused',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        name: 'paused',
+        type: 'bool',
+      },
+    ],
+    name: 'LogTokenPaused',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        name: 'previousOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnershipRenounced',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        name: 'previousOwner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnershipTransferred',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Approval',
+    type: 'event',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'monetaryPolicy_',
+        type: 'address',
+      },
+    ],
+    name: 'setMonetaryPolicy',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'paused',
+        type: 'bool',
+      },
+    ],
+    name: 'setRebasePaused',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'paused',
+        type: 'bool',
+      },
+    ],
+    name: 'setTokenPaused',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'epoch',
+        type: 'uint256',
+      },
+      {
+        name: 'supplyDelta',
+        type: 'int256',
+      },
+    ],
+    name: 'rebase',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'owner',
+        type: 'address',
+      },
+    ],
+    name: 'initialize',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'name',
+        type: 'string',
+      },
+      {
+        name: 'symbol',
+        type: 'string',
+      },
+      {
+        name: 'decimals',
+        type: 'uint8',
+      },
+    ],
+    name: 'initialize',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: 'who',
+        type: 'address',
+      },
+    ],
+    name: 'balanceOf',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'to',
+        type: 'address',
+      },
+      {
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'transfer',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        name: 'spender',
+        type: 'address',
+      },
+    ],
+    name: 'allowance',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'from',
+        type: 'address',
+      },
+      {
+        name: 'to',
+        type: 'address',
+      },
+      {
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'transferFrom',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'approve',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        name: 'addedValue',
+        type: 'uint256',
+      },
+    ],
+    name: 'increaseAllowance',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        name: 'subtractedValue',
+        type: 'uint256',
+      },
+    ],
+    name: 'decreaseAllowance',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+]

--- a/frontend/src/utils/abis/UFragmentsPolicy.ts
+++ b/frontend/src/utils/abis/UFragmentsPolicy.ts
@@ -1,0 +1,391 @@
+export const UFRAGMENTS_POLICY_ABI = [
+  {
+    constant: true,
+    inputs: [],
+    name: 'minRebaseTimeIntervalSec',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'lastRebaseTimestampSec',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'marketOracle',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'rebaseLag',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'rebaseWindowOffsetSec',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [],
+    name: 'renounceOwnership',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'owner',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'isOwner',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'epoch',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'rebaseWindowLengthSec',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'cpiOracle',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'uFrags',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'deviationThreshold',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'transferOwnership',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        name: 'epoch',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'exchangeRate',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'cpi',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'requestedSupplyAdjustment',
+        type: 'int256',
+      },
+      {
+        indexed: false,
+        name: 'timestampSec',
+        type: 'uint256',
+      },
+    ],
+    name: 'LogRebase',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        name: 'previousOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnershipRenounced',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        name: 'previousOwner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'newOwner',
+        type: 'address',
+      },
+    ],
+    name: 'OwnershipTransferred',
+    type: 'event',
+  },
+  {
+    constant: false,
+    inputs: [],
+    name: 'rebase',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'cpiOracle_',
+        type: 'address',
+      },
+    ],
+    name: 'setCpiOracle',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'marketOracle_',
+        type: 'address',
+      },
+    ],
+    name: 'setMarketOracle',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'deviationThreshold_',
+        type: 'uint256',
+      },
+    ],
+    name: 'setDeviationThreshold',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'rebaseLag_',
+        type: 'uint256',
+      },
+    ],
+    name: 'setRebaseLag',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'minRebaseTimeIntervalSec_',
+        type: 'uint256',
+      },
+      {
+        name: 'rebaseWindowOffsetSec_',
+        type: 'uint256',
+      },
+      {
+        name: 'rebaseWindowLengthSec_',
+        type: 'uint256',
+      },
+    ],
+    name: 'setRebaseTimingParameters',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'owner_',
+        type: 'address',
+      },
+      {
+        name: 'uFrags_',
+        type: 'address',
+      },
+      {
+        name: 'baseCpi_',
+        type: 'uint256',
+      },
+    ],
+    name: 'initialize',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'sender',
+        type: 'address',
+      },
+    ],
+    name: 'initialize',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'inRebaseWindow',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+]

--- a/frontend/src/utils/ampleforth.ts
+++ b/frontend/src/utils/ampleforth.ts
@@ -1,0 +1,56 @@
+import { Contract, ethers, Signer } from 'ethers'
+import { formatUnits } from 'ethers/lib/utils'
+import { toChecksumAddress } from 'web3-utils'
+import { AMPL_LAUNCH_DATE, DAY_IN_MS, INITIAL_SUPPLY } from '../constants'
+import { RewardSchedule, SupplyInfo } from '../types'
+import { UFRAGMENTS_POLICY_ABI } from './abis/UFragmentsPolicy'
+import { loadHistoricalLogs } from './eth'
+import * as ls from './cache'
+
+export const getTotalRewardShares = async (
+  rewardSchedules: RewardSchedule[],
+  policyAddress: string,
+  epoch: number,
+  decimals = 9,
+  signer?: Signer,
+) => {
+  const supplyHistory = await getSupplyHistory(policyAddress, epoch, decimals, signer)
+  const getShares = (schedule: RewardSchedule) =>
+    parseFloat(formatUnits(schedule.rewardAmount, decimals)) / getSupplyOn(parseInt(schedule.start, 10), supplyHistory)
+  return rewardSchedules.reduce((acc, schedule) => acc + getShares(schedule), 0)
+}
+
+export const getSupplyOn = (timestamp: number, supplyHistory: SupplyInfo[]) => {
+  if (supplyHistory.length === 0) return 0
+
+  let index = supplyHistory.findIndex(({ timestamp: ts }) => timestamp < ts)
+  if (index < 0) {
+    index = supplyHistory.length
+  }
+  return supplyHistory[Math.max(index - 1, 0)].supply
+}
+
+export const getSupplyHistory = async (policyAddress: string, epoch: number, decimals: number, signer?: Signer) =>
+  ls.computeAndCache<SupplyInfo[]>(
+    async () => {
+      const policy = new Contract(policyAddress, UFRAGMENTS_POLICY_ABI, signer || ethers.getDefaultProvider())
+      const eventLogs = await loadHistoricalLogs(policy, 'LogRebase')
+      const historyFromLogs: SupplyInfo[] = eventLogs
+        .filter((log) => log.args)
+        .map((log) => ({
+          timestamp: parseInt(log.args!.timestampSec.toString(), 10),
+          supply: parseFloat(formatUnits(log.args!.requestedSupplyAdjustment, decimals)),
+          epoch: parseInt(log.args!.epoch, 10),
+        }))
+      const supplyHistory: SupplyInfo[] = [{ timestamp: AMPL_LAUNCH_DATE, supply: INITIAL_SUPPLY, epoch: 0 }].concat(
+        historyFromLogs,
+      )
+      for (let i = 1; i < supplyHistory.length; i++) {
+        supplyHistory[i].supply += supplyHistory[i - 1].supply
+      }
+      return supplyHistory
+    },
+    `${toChecksumAddress(policyAddress)}|supplyHistory`,
+    DAY_IN_MS,
+    (cached) => cached.length > 0 && cached[cached.length - 1].epoch >= epoch,
+  )

--- a/frontend/src/utils/cache.ts
+++ b/frontend/src/utils/cache.ts
@@ -15,3 +15,18 @@ export const get = (key: string): any => {
   }
   return null
 }
+
+// Returns the cached value if it exists and useCache(cachedValue) return true
+// Otherwise, compute the value, and cache it
+export async function computeAndCache<T>(
+  getValueOperation: () => Promise<T>,
+  key: string,
+  ttl: number,
+  useCache: (cached: T) => boolean = () => true,
+): Promise<T> {
+  const cachedValue = get(key)
+  if (cachedValue && useCache(cachedValue)) return cachedValue
+  const value = await getValueOperation()
+  set(key, value, ttl)
+  return value
+}

--- a/frontend/src/utils/eth.ts
+++ b/frontend/src/utils/eth.ts
@@ -1,0 +1,9 @@
+import { Contract, ethers } from 'ethers'
+import { UFRG_INIT_BLOCK } from '../constants'
+
+export const getDefaultProvider = () => ethers.getDefaultProvider()
+
+export const loadHistoricalLogs = async (contract: Contract, eventName: string, startBlock = UFRG_INIT_BLOCK) => {
+  const filter = contract.filters[eventName]()
+  return contract.queryFilter(filter, startBlock, 'latest')
+}

--- a/frontend/src/utils/eth.ts
+++ b/frontend/src/utils/eth.ts
@@ -1,7 +1,13 @@
 import { Contract, ethers } from 'ethers'
 import { UFRG_INIT_BLOCK } from '../constants'
 
-export const getDefaultProvider = () => ethers.getDefaultProvider()
+export const getDefaultProvider = () => {
+  if (process.env.NODE_ENV === 'development') {
+    return new ethers.providers.JsonRpcProvider('http://localhost:8545', { name: 'localhost', chainId: 1337 })
+  }
+  // TODO: pass infura api key as param
+  return ethers.getDefaultProvider()
+}
 
 export const loadHistoricalLogs = async (contract: Contract, eventName: string, startBlock = UFRG_INIT_BLOCK) => {
   const filter = contract.filters[eventName]()

--- a/frontend/src/utils/rewardToken.ts
+++ b/frontend/src/utils/rewardToken.ts
@@ -1,0 +1,63 @@
+import { Contract, Signer } from 'ethers'
+import { formatUnits } from 'ethers/lib/utils'
+import { RewardToken } from '../constants'
+import { RewardSchedule, RewardTokenInfo } from '../types'
+import { UFRAGMENTS_ABI } from './abis/UFragments'
+import { UFRAGMENTS_POLICY_ABI } from './abis/UFragmentsPolicy'
+import { getTotalRewardShares } from './ampleforth'
+import { defaultTokenInfo, getTokenInfo } from './token'
+
+export const defaultRewardTokenInfo = (): RewardTokenInfo => ({
+  ...defaultTokenInfo(),
+  getTotalRewards: async () => 0,
+})
+
+export const getRewardTokenInfo = async (tokenAddress: string, token: RewardToken, signer: Signer) => {
+  switch (token) {
+    case RewardToken.MOCK:
+      return getMockToken(tokenAddress, signer)
+    case RewardToken.AMPL:
+      return getAMPLToken(tokenAddress, signer)
+    default:
+      throw new Error(`Handler for ${token} not found`)
+  }
+}
+
+const getMockToken = async (tokenAddress: string, signer: Signer): Promise<RewardTokenInfo> => {
+  const tokenInfo = await getTokenInfo(tokenAddress, signer)
+  const getTotalRewards = async (rewardSchedules: RewardSchedule[]) =>
+    rewardSchedules.reduce(
+      (acc, schedule) => acc + parseFloat(formatUnits(schedule.rewardAmount, tokenInfo.decimals)),
+      0,
+    )
+  return {
+    ...tokenInfo,
+    getTotalRewards,
+  }
+}
+
+const getAMPLToken = async (tokenAddress: string, signer: Signer): Promise<RewardTokenInfo> => {
+  const contract = new Contract(tokenAddress, UFRAGMENTS_ABI, signer)
+  const tokenInfo = await getTokenInfo(tokenAddress, signer)
+  const policyAddress: string = await contract.monetaryPolicy()
+  const policy = new Contract(policyAddress, UFRAGMENTS_POLICY_ABI, signer)
+
+  const totalSupply = await contract.totalSupply()
+  const epoch = parseInt(await policy.epoch(), 10)
+
+  const getTotalRewards = async (rewardSchedules: RewardSchedule[]) => {
+    const totalRewardShares = await getTotalRewardShares(
+      rewardSchedules,
+      policyAddress,
+      epoch,
+      tokenInfo.decimals,
+      signer,
+    )
+    return totalRewardShares * totalSupply
+  }
+
+  return {
+    ...tokenInfo,
+    getTotalRewards,
+  }
+}

--- a/frontend/src/utils/stats.ts
+++ b/frontend/src/utils/stats.ts
@@ -1,4 +1,4 @@
-import { BigNumber, BigNumberish, Signer } from 'ethers'
+import { BigNumber, BigNumberish } from 'ethers'
 import { toChecksumAddress } from 'web3-utils'
 import { formatUnits } from 'ethers/lib/utils'
 import { getCurrentUnlockedRewards, getCurrentVaultReward, getFutureUnlockedRewards } from '../sdk/stats'
@@ -7,6 +7,7 @@ import {
   GeyserStats,
   Lock,
   RewardTokenInfo,
+  SignerOrProvider,
   StakingTokenInfo,
   TokenInfo,
   UserStats,
@@ -14,14 +15,15 @@ import {
   VaultStats,
 } from '../types'
 import { ERC20Balance } from '../sdk'
-import { DAY_IN_SEC, YEAR_IN_SEC } from '../constants'
+import { DAY_IN_SEC, GEYSER_STATS_CACHE_TIME_MS, YEAR_IN_SEC } from '../constants'
 import { getCurrentPrice } from './price'
+import * as ls from './cache'
 
 const nowInSeconds = () => Math.round(Date.now() / 1000)
 
 export const defaultUserStats = (): UserStats => ({
   apy: 0,
-  currentMultiplier: 0,
+  currentMultiplier: 1.0,
   currentReward: 0,
 })
 
@@ -59,11 +61,16 @@ export const getGeyserStats = async (
   geyser: Geyser,
   stakingTokenInfo: StakingTokenInfo,
   rewardTokenInfo: RewardTokenInfo,
-): Promise<GeyserStats> => ({
-  duration: getGeyserDuration(geyser),
-  totalDeposit: getGeyserTotalDeposit(geyser, stakingTokenInfo),
-  totalRewards: await rewardTokenInfo.getTotalRewards(geyser.rewardSchedules),
-})
+): Promise<GeyserStats> =>
+  ls.computeAndCache<GeyserStats>(
+    async () => ({
+      duration: getGeyserDuration(geyser),
+      totalDeposit: getGeyserTotalDeposit(geyser, stakingTokenInfo),
+      totalRewards: await rewardTokenInfo.getTotalRewards(geyser.rewardSchedules),
+    }),
+    `${toChecksumAddress(geyser.id)}|stats`,
+    GEYSER_STATS_CACHE_TIME_MS,
+  )
 
 const getTotalStakeUnits = (geyser: Geyser, timestamp: number) => {
   const { totalStake, totalStakeUnits: cachedTotalStakeUnits, lastUpdate } = geyser
@@ -82,10 +89,10 @@ const getLockStakeUnits = (lock: Lock, timestamp: number) => {
 /**
  * Returns the amount of reward token that will be unlocked between now and `end`
  */
-const getPoolDrip = async (geyser: Geyser, end: number, signer: Signer) => {
+const getPoolDrip = async (geyser: Geyser, end: number, signerOrProvider: SignerOrProvider) => {
   const geyserAddress = toChecksumAddress(geyser.id)
-  return (await getFutureUnlockedRewards(geyserAddress, end, signer)).sub(
-    await getCurrentUnlockedRewards(geyserAddress, signer),
+  return (await getFutureUnlockedRewards(geyserAddress, end, signerOrProvider)).sub(
+    await getCurrentUnlockedRewards(geyserAddress, signerOrProvider),
   )
 }
 
@@ -99,11 +106,11 @@ export const getUserDrip = async (
   lock: Lock,
   additionalStakes: BigNumberish,
   duration: number,
-  signer: Signer,
+  signerOrProvider: SignerOrProvider,
 ) => {
   const now = nowInSeconds()
   const afterDuration = now + duration
-  const poolDrip = await getPoolDrip(geyser, afterDuration, signer)
+  const poolDrip = await getPoolDrip(geyser, afterDuration, signerOrProvider)
   const stakeUnitsFromAdditionalStake = BigNumber.from(additionalStakes).mul(duration)
   const totalStakeUnitsAfterDuration = getTotalStakeUnits(geyser, afterDuration).add(stakeUnitsFromAdditionalStake)
   const lockStakeUnitsAfterDuration = getLockStakeUnits(lock, afterDuration).add(stakeUnitsFromAdditionalStake)
@@ -114,10 +121,15 @@ export const getUserDrip = async (
   )
 }
 
-export const getStakeDrip = async (geyser: Geyser, stake: BigNumberish, duration: number, signer: Signer) => {
+export const getStakeDrip = async (
+  geyser: Geyser,
+  stake: BigNumberish,
+  duration: number,
+  signerOrProvider: SignerOrProvider,
+) => {
   const now = nowInSeconds()
   const afterDuration = now + duration
-  const poolDrip = await getPoolDrip(geyser, afterDuration, signer)
+  const poolDrip = await getPoolDrip(geyser, afterDuration, signerOrProvider)
   const stakeUnitsFromStake = BigNumber.from(stake).mul(duration)
   const totalStakeUnitsAfterDuration = getTotalStakeUnits(geyser, afterDuration).add(stakeUnitsFromStake)
   if (totalStakeUnitsAfterDuration.isZero()) return 0
@@ -143,7 +155,7 @@ export const getUserAPY = async (
   stakingTokenInfo: StakingTokenInfo,
   rewardTokenInfo: TokenInfo,
   additionalStakes: BigNumberish,
-  signer: Signer,
+  signerOrProvider: SignerOrProvider,
 ) => {
   const { scalingTime } = geyser
   const { amount: stakedAmount } = lock
@@ -152,7 +164,13 @@ export const getUserAPY = async (
   const rewardTokenPrice = await getCurrentPrice(rewardTokenSymbol)
   const geyserDuration = getGeyserDuration(geyser)
   const calcPeriod = Math.max(Math.min(geyserDuration, parseInt(scalingTime, 10)), DAY_IN_SEC)
-  const userDripAfterPeriod = await getUserDrip(geyser, lock, additionalStakes, parseInt(scalingTime, 10), signer)
+  const userDripAfterPeriod = await getUserDrip(
+    geyser,
+    lock,
+    additionalStakes,
+    parseInt(scalingTime, 10),
+    signerOrProvider,
+  )
 
   const inflow = parseFloat(formatUnits(stakedAmount, stakingTokenDecimals)) * stakingTokenPrice
   const outflow = parseFloat(formatUnits(userDripAfterPeriod, rewardTokenDecimals)) * rewardTokenPrice
@@ -167,26 +185,31 @@ const getPoolAPY = async (
   geyser: Geyser,
   stakingTokenInfo: StakingTokenInfo,
   rewardTokenInfo: TokenInfo,
-  signer: Signer,
-) => {
-  const { scalingTime } = geyser
-  const { price: stakingTokenPrice } = stakingTokenInfo
-  const { decimals: rewardTokenDecimals, symbol: rewardTokenSymbol } = rewardTokenInfo
-  if (!rewardTokenSymbol) return 0
-  const rewardTokenPrice = await getCurrentPrice('AMPL')
+  signerOrProvider: SignerOrProvider,
+) =>
+  ls.computeAndCache<number>(
+    async () => {
+      const { scalingTime } = geyser
+      const { price: stakingTokenPrice } = stakingTokenInfo
+      const { decimals: rewardTokenDecimals, symbol: rewardTokenSymbol } = rewardTokenInfo
+      if (!rewardTokenSymbol) return 0
+      const rewardTokenPrice = await getCurrentPrice('AMPL')
 
-  const inflow = 20000.0 // avg_deposit: 20,000 USD
+      const inflow = 20000.0 // avg_deposit: 20,000 USD
 
-  const stake = BigNumber.from(Math.round(inflow / stakingTokenPrice))
-  const geyserDuration = getGeyserDuration(geyser)
-  const calcPeriod = Math.max(Math.min(geyserDuration, parseInt(scalingTime, 10)), DAY_IN_SEC)
-  const stakeDripAfterPeriod = await getStakeDrip(geyser, stake, parseInt(scalingTime, 10), signer)
-  if (stakeDripAfterPeriod === 0) return 0
+      const stake = BigNumber.from(Math.round(inflow / stakingTokenPrice))
+      const geyserDuration = getGeyserDuration(geyser)
+      const calcPeriod = Math.max(Math.min(geyserDuration, parseInt(scalingTime, 10)), DAY_IN_SEC)
+      const stakeDripAfterPeriod = await getStakeDrip(geyser, stake, parseInt(scalingTime, 10), signerOrProvider)
+      if (stakeDripAfterPeriod === 0) return 0
 
-  const outflow = parseFloat(formatUnits(stakeDripAfterPeriod, rewardTokenDecimals)) * rewardTokenPrice
-  const periods = YEAR_IN_SEC / calcPeriod
-  return calculateAPY(inflow, outflow, periods)
-}
+      const outflow = parseFloat(formatUnits(stakeDripAfterPeriod, rewardTokenDecimals)) * rewardTokenPrice
+      const periods = YEAR_IN_SEC / calcPeriod
+      return calculateAPY(inflow, outflow, periods)
+    },
+    `${toChecksumAddress(geyser.id)}|poolAPY`,
+    GEYSER_STATS_CACHE_TIME_MS,
+  )
 
 /**
  * Reward multiplier for the stakes of a vault on a geyser
@@ -198,7 +221,7 @@ const getPoolAPY = async (
  *
  * The actual current multiplier is then { minMultiplier + currentRewards / maxRewards * (maxMultiplier - minMultiplier) }
  */
-const getCurrentMultiplier = async (geyser: Geyser, vault: Vault, lock: Lock, signer: Signer) => {
+const getCurrentMultiplier = async (geyser: Geyser, vault: Vault, lock: Lock, signerOrProvider: SignerOrProvider) => {
   const { scalingFloor, scalingCeiling } = geyser
   const geyserAddress = toChecksumAddress(geyser.id)
   const vaultAddress = toChecksumAddress(vault.id)
@@ -210,10 +233,13 @@ const getCurrentMultiplier = async (geyser: Geyser, vault: Vault, lock: Lock, si
   const lockStakeUnits = getLockStakeUnits(lock, now)
   if (totalStakeUnits.isZero() || lockStakeUnits.isZero()) return minMultiplier
 
-  const currentUnlockedRewards = await getCurrentUnlockedRewards(geyserAddress, signer)
+  const currentUnlockedRewards = await getCurrentUnlockedRewards(geyserAddress, signerOrProvider)
   if (currentUnlockedRewards.isZero()) return minMultiplier
 
-  const currentRewards = parseInt((await getCurrentVaultReward(vaultAddress, geyserAddress, signer)).toString(), 10)
+  const currentRewards = parseInt(
+    (await getCurrentVaultReward(vaultAddress, geyserAddress, signerOrProvider)).toString(),
+    10,
+  )
   const maxRewards =
     parseInt(currentUnlockedRewards.mul(lockStakeUnits).toString(), 10) / parseInt(totalStakeUnits.toString(), 10)
   const fraction = currentRewards / maxRewards
@@ -227,26 +253,26 @@ export const getUserStats = async (
   lock: Lock | null,
   stakingTokenInfo: StakingTokenInfo,
   rewardTokenInfo: TokenInfo,
-  signer: Signer,
+  signerOrProvider: SignerOrProvider,
 ): Promise<UserStats> => {
   if (!vault || !lock) {
     return {
       ...defaultUserStats(),
-      apy: await getPoolAPY(geyser, stakingTokenInfo, rewardTokenInfo, signer),
+      apy: await getPoolAPY(geyser, stakingTokenInfo, rewardTokenInfo, signerOrProvider),
     }
   }
   const vaultAddress = toChecksumAddress(vault.id)
   const geyserAddress = toChecksumAddress(geyser.id)
   const { decimals: rewardTokenDecimals } = rewardTokenInfo
   const { amount } = lock
-  const currentRewards = await getCurrentVaultReward(vaultAddress, geyserAddress, signer)
+  const currentRewards = await getCurrentVaultReward(vaultAddress, geyserAddress, signerOrProvider)
   const formattedCurrentRewards = parseFloat(formatUnits(currentRewards, rewardTokenDecimals))
   const apy = BigNumber.from(amount).isZero()
-    ? await getPoolAPY(geyser, stakingTokenInfo, rewardTokenInfo, signer)
-    : await getUserAPY(geyser, lock, stakingTokenInfo, rewardTokenInfo, 0, signer)
+    ? await getPoolAPY(geyser, stakingTokenInfo, rewardTokenInfo, signerOrProvider)
+    : await getUserAPY(geyser, lock, stakingTokenInfo, rewardTokenInfo, 0, signerOrProvider)
   return {
     apy,
-    currentMultiplier: await getCurrentMultiplier(geyser, vault, lock, signer),
+    currentMultiplier: await getCurrentMultiplier(geyser, vault, lock, signerOrProvider),
     currentReward: formattedCurrentRewards,
   }
 }
@@ -257,16 +283,16 @@ export const getVaultStats = async (
   rewardTokenInfo: TokenInfo,
   vault: Vault | null,
   lock: Lock | null,
-  signer: Signer,
+  signerOrProvider: SignerOrProvider,
 ): Promise<VaultStats> => {
   if (!vault) return defaultVaultStats()
   const vaultAddress = toChecksumAddress(vault.id)
   const { address: stakingTokenAddress, decimals: stakingTokenDecimals } = stakingTokenInfo
   const { address: rewardTokenAddress, decimals: rewardTokenDecimals } = rewardTokenInfo
-  const stakingTokenBalance = await ERC20Balance(toChecksumAddress(stakingTokenAddress), vaultAddress, signer)
-  const rewardTokenBalance = await ERC20Balance(toChecksumAddress(rewardTokenAddress), vaultAddress, signer)
+  const stakingTokenBalance = await ERC20Balance(toChecksumAddress(stakingTokenAddress), vaultAddress, signerOrProvider)
+  const rewardTokenBalance = await ERC20Balance(toChecksumAddress(rewardTokenAddress), vaultAddress, signerOrProvider)
   const platformTokenBalances = await Promise.all(
-    platformTokenInfos.map(({ address }) => ERC20Balance(toChecksumAddress(address), vaultAddress, signer)),
+    platformTokenInfos.map(({ address }) => ERC20Balance(toChecksumAddress(address), vaultAddress, signerOrProvider)),
   )
 
   const formattedStakingTokenBalance = parseFloat(formatUnits(stakingTokenBalance, stakingTokenDecimals))

--- a/frontend/src/utils/token.ts
+++ b/frontend/src/utils/token.ts
@@ -2,7 +2,7 @@ import { Signer } from 'ethers'
 import { toChecksumAddress } from 'web3-utils'
 import { ERC20Decimals, ERC20Name, ERC20Symbol } from '../sdk'
 import { TokenInfo } from '../types'
-import * as ls from './ttl'
+import * as ls from './cache'
 import { CONST_CACHE_TIME_MS } from '../constants'
 
 export const getTokenInfo = async (
@@ -11,21 +11,19 @@ export const getTokenInfo = async (
   ttl: number = CONST_CACHE_TIME_MS,
 ): Promise<TokenInfo> => {
   const address = toChecksumAddress(tokenAddress)
-  const cacheKey = `${address}|tokenInfo`
-  const cachedValue = ls.get(cacheKey)
-  if (cachedValue) {
-    return cachedValue as TokenInfo
-  }
-
-  const value: TokenInfo = {
-    address,
-    name: await ERC20Name(address, signer),
-    symbol: await ERC20Symbol(address, signer),
-    decimals: await ERC20Decimals(address, signer),
-  }
-
-  ls.set(cacheKey, value, ttl)
-  return value
+  return ls.computeAndCache<TokenInfo>(
+    async () => {
+      const value: TokenInfo = {
+        address,
+        name: await ERC20Name(address, signer),
+        symbol: await ERC20Symbol(address, signer),
+        decimals: await ERC20Decimals(address, signer),
+      }
+      return value
+    },
+    `${address}|tokenInfo`,
+    ttl,
+  )
 }
 
 export const defaultTokenInfo = (): TokenInfo => ({

--- a/frontend/src/utils/token.ts
+++ b/frontend/src/utils/token.ts
@@ -1,13 +1,12 @@
-import { Signer } from 'ethers'
 import { toChecksumAddress } from 'web3-utils'
 import { ERC20Decimals, ERC20Name, ERC20Symbol } from '../sdk'
-import { TokenInfo } from '../types'
+import { SignerOrProvider, TokenInfo } from '../types'
 import * as ls from './cache'
 import { CONST_CACHE_TIME_MS } from '../constants'
 
 export const getTokenInfo = async (
   tokenAddress: string,
-  signer: Signer,
+  signerOrProvider: SignerOrProvider,
   ttl: number = CONST_CACHE_TIME_MS,
 ): Promise<TokenInfo> => {
   const address = toChecksumAddress(tokenAddress)
@@ -15,9 +14,9 @@ export const getTokenInfo = async (
     async () => {
       const value: TokenInfo = {
         address,
-        name: await ERC20Name(address, signer),
-        symbol: await ERC20Symbol(address, signer),
-        decimals: await ERC20Decimals(address, signer),
+        name: await ERC20Name(address, signerOrProvider),
+        symbol: await ERC20Symbol(address, signerOrProvider),
+        decimals: await ERC20Decimals(address, signerOrProvider),
       }
       return value
     },

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -22,7 +22,6 @@ type Geyser @entity {
   lastUpdate: BigInt!
   rewardSchedules: [RewardSchedule]! @derivedFrom(field: "geyser")
   locks: [Lock]! @derivedFrom(field: "geyser")
-  totalRewardsClaimed: BigInt!
 }
 
 type User @entity {

--- a/subgraph/src/geyser.ts
+++ b/subgraph/src/geyser.ts
@@ -79,7 +79,6 @@ export function handleGeyserCreated(event: GeyserCreated): void {
   entity.scalingTime = geyserData.rewardScaling.time
   entity.status = 'Online'
   entity.bonusTokens = []
-  entity.totalRewardsClaimed = BigInt.fromI32(0)
 
   _updateGeyser(entity, geyserContract, event.block.timestamp)
 }
@@ -158,9 +157,6 @@ export function handleRewardClaimed(event: RewardClaimed): void {
   entity.amount = entity.amount.plus(event.params.amount)
   entity.lastUpdate = event.block.timestamp
 
-  let geyser = Geyser.load(event.address.toHex()) as Geyser
-  geyser.totalRewardsClaimed = geyser.totalRewardsClaimed.plus(event.params.amount)
-  geyser.save()
   updateGeyser(event.address, event.block.timestamp)
 
   entity.save()

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -9,13 +9,15 @@ export async function getTimestamp() {
 
 export async function increaseTime(seconds: number) {
   const time = await getTimestamp()
+  // instead of using evm_increaseTime, we can pass in the timestamp
+  // the next block should setup as the mining time
+  const expectedEndTime = time + seconds - 1
   await network.provider.request({
-    method: 'evm_increaseTime',
-    params: [seconds - 1],
+    method: 'evm_mine',
+    params: [expectedEndTime],
   })
-  await network.provider.request({ method: 'evm_mine' })
-  if (time + seconds - 1 !== (await getTimestamp())) {
-    throw new Error('evm_increaseTime failed')
+  if (expectedEndTime !== (await getTimestamp())) {
+    throw new Error('evm_mine failed')
   }
 }
 


### PR DESCRIPTION
## Stats Functions
We want to be able to compute the estimated rewards and estimated APY of a vault as the user inputs their desired stakes. Two functions to compute those were included in the `StatsContext`.

## Total Rewards
In this [previous PR](https://github.com/hyplabs/token-geyser-v2/pull/14), a field to the subgraph was added to keep track of `totalRewards`. However, it will not work if the token is a rebase token (i.e. AMPL). This PR reverts the subgraph changes, and instead uses historical logs scanning (same logic as V1) to calculate the total rewards.

## Default Provider
Added a default provider, which will be used to call contract functions that do not require transactions. This enables users to view geyser stats without having to connect their wallet (V1 behaviour)

## Caching
Geyser stats will be cached, can be changed under `constants.ts`, now set to 1 minute. User specific stats will not be cached, but we can look into caching them too if there's such need.

## Geyser Contract Unstake Bug

#### Problem
Suppose a user stakes two times: they stake 2 units the first time, and 1 unit the second time, then the internal staked state would be `["2", "1"]`. If the user then unstakes exactly 1 unit, the internal state somehow gets updated to `["0"]`, instead of `["2"]`.  This is because the contract did not handle correctly the case where the unstake amount is exactly equal to the amount staked in the last stake. This has been fixed.

#### Testing
In addition, I also included a test case in `test/Geyser.ts` to reflect this change: I made sure that the test would fail without the fix, and it passes with the fix (aka testing the test).

## Geyser Tests Indeterminacy
Another thing that was fixed was the indeterminacy of the tests in `test/Geyser.ts`. Previously, it had some issues with timestamp manipulation, but this has been fixed. Now, all the tests pass.
