### PR TITLE
fix geyser unstake bug

### DIFF
--- a/contracts/Geyser.sol
+++ b/contracts/Geyser.sol
@@ -891,8 +891,14 @@ contract Geyser is IGeyser, Powered, OwnableUpgradeable {
             // some stakes have been completely or partially unstaked
             // delete fully unstaked stakes
             while (vaultData.stakes.length > out.newStakesCount) vaultData.stakes.pop();
-            // update partially unstaked stake
-            vaultData.stakes[out.newStakesCount.sub(1)].amount = out.lastStakeAmount;
+
+            // note: if out.lastStakeAmount == 0, it means that the amount unstaked was exactly the amount
+            // staked in vaultData.stakes[vaultData.stakes.length.sub(1)],
+            // so there is no need to update the stake in vaultData.stakes[vaultData.stakes.length.sub(2)]
+            if (out.lastStakeAmount > 0) {
+                // update partially unstaked stake
+                vaultData.stakes[out.newStakesCount.sub(1)].amount = out.lastStakeAmount;
+            }
         }
 
         // update cached stake totals

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -9,13 +9,15 @@ export async function getTimestamp() {
 
 export async function increaseTime(seconds: number) {
   const time = await getTimestamp()
+  // instead of using evm_increaseTime, we can pass in the timestamp
+  // the next block should setup as the mining time
+  const expectedEndTime = time + seconds - 1
   await network.provider.request({
-    method: 'evm_increaseTime',
-    params: [seconds - 1],
+    method: 'evm_mine',
+    params: [expectedEndTime],
   })
-  await network.provider.request({ method: 'evm_mine' })
-  if (time + seconds - 1 !== (await getTimestamp())) {
-    throw new Error('evm_increaseTime failed')
+  if (expectedEndTime !== (await getTimestamp())) {
+    throw new Error('evm_mine failed')
   }
 }
 


### PR DESCRIPTION
## Geyser Contract Unstake Bug

#### Problem
Suppose a user stakes two times: they stake 2 units the first time, and 1 unit the second time, then the internal staked state would be `["2", "1"]`. If the user then unstakes exactly 1 unit, the internal state somehow gets updated to `["0"]`, instead of `["2"]`.  This is because the contract did not handle correctly the case where the unstake amount is exactly equal to the amount staked in the last stake. This has been fixed.

#### Testing
In addition, I also included a test case in `test/Geyser.ts` to reflect this change: I made sure that the test would fail without the fix, and it passes with the fix (aka testing the test).

## Geyser Tests Indeterminacy
Another thing that was fixed was the indeterminacy of the tests in `test/Geyser.ts`. Previously, it had some issues with timestamp manipulation, but this has been fixed. Now, all the tests pass.