### PR TITLE
finalize stats functionalities

### DIFF
--- a/frontend/src/components/GeyserFirstContainer.tsx
+++ b/frontend/src/components/GeyserFirstContainer.tsx
@@ -4,7 +4,7 @@ import { GeyserStakeView } from './GeyserStakeView'
 import { GeyserFirstOverlay } from '../styling/styles'
 import { ToggleView } from './ToggleView'
 import tw from 'twin.macro'
-import { GeyserContext } from 'context/GeyserContext'
+import { GeyserContext } from '../context/GeyserContext'
 import { GeyserStatsView } from './GeyserStatsView'
 
 interface Props {}

--- a/frontend/src/components/GeyserStats.tsx
+++ b/frontend/src/components/GeyserStats.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components/macro'
-import { ResponsiveText } from 'styling/styles'
+import { ResponsiveText } from '../styling/styles'
 import tw from 'twin.macro'
 import { GeyserStatsBox } from './GeyserStatsBox'
 

--- a/frontend/src/components/GeyserStatsBox.tsx
+++ b/frontend/src/components/GeyserStatsBox.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components/macro'
-import { ResponsiveSubText, ResponsiveText } from 'styling/styles'
+import { ResponsiveSubText, ResponsiveText } from '../styling/styles'
 import tw from 'twin.macro'
 
 interface Props {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,20 +1,19 @@
 import { useContext } from 'react'
 import styled, { css } from 'styled-components/macro'
 import tw from 'twin.macro'
-import { toChecksumAddress } from 'web3-utils'
 import { GeyserContext } from '../context/GeyserContext'
 import { VaultContext } from '../context/VaultContext'
 import { Dropdown } from './Dropdown'
 import { HeaderWalletButton } from './HeaderWalletButton'
 import { ToolButton } from './ToolButton'
 import copy from 'assets/clipboard.svg'
-import { ResponsiveText } from 'styling/styles'
+import { ResponsiveText } from '../styling/styles'
 
 export const Header = () => {
-  const { geysers, selectGeyserById, selectedGeyser, geyserAddressToName } = useContext(GeyserContext)
+  const { geysers, selectGeyserByName, selectedGeyser, getGeyserName } = useContext(GeyserContext)
   const { vaults, selectVaultById, selectedVault } = useContext(VaultContext)
 
-  const handleGeyserChange = (geyserId: string) => selectGeyserById(geyserId)
+  const handleGeyserChange = (geyserName: string) => selectGeyserByName(geyserName)
   const handleVaultChange = (vaultId: string) => selectVaultById(vaultId)
 
   const handleCopyVaultID = () => navigator.clipboard.writeText(selectedVault!.id)
@@ -46,8 +45,8 @@ export const Header = () => {
             <Label>Geyser</Label>
             {geysers.length > 0 && (
               <Dropdown
-                options={geysers.map((geyser) => geyser.id)}
-                selectedOption={selectedGeyser ? selectedGeyser.id : geysers[0].id}
+                options={geysers.map((geyser) => getGeyserName(geyser.id))}
+                selectedOption={getGeyserName(selectedGeyser ? selectedGeyser.id : geysers[0].id)}
                 onChange={handleGeyserChange}
               />
             )}

--- a/frontend/src/components/MyStats.tsx
+++ b/frontend/src/components/MyStats.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components/macro'
 import tw from 'twin.macro'
-import { ResponsiveText } from 'styling/styles'
+import { ResponsiveText } from '../styling/styles'
 import { GeyserStatsBox } from './GeyserStatsBox'
 import { MyStatsBox } from './MyStatsBox'
 import { ToolButton } from './ToolButton'

--- a/frontend/src/config/geyser.ts
+++ b/frontend/src/config/geyser.ts
@@ -1,11 +1,24 @@
-import { StakingToken } from '../constants'
+import { RewardToken, StakingToken } from '../constants'
 import { GeyserConfig } from '../types'
 
+/**
+ *
+ * `address` should be the actual address to which the geyser contract was deployed
+ *
+ */
 const mockGeyserConfigs: GeyserConfig[] = [
   {
     name: 'Trinity V1 (Balancer BTC-ETH-AMPL)',
-    address: '0x0dcd1bf9a1b36ce34237eeafef220932846bcd82',
+    address: '0x0000000000000000000000000000000000000000',
     stakingToken: StakingToken.MOCK,
+    rewardToken: RewardToken.MOCK,
+    platformTokenConfigs: [],
+  },
+  {
+    name: 'Beehive V3 (Uniswap ETH-AMPL)',
+    address: '0x0000000000000000000000000000000000000000',
+    stakingToken: StakingToken.MOCK,
+    rewardToken: RewardToken.MOCK,
     platformTokenConfigs: [],
   },
 ]
@@ -15,6 +28,7 @@ const mainnetGeyserConfigs: GeyserConfig[] = [
     name: 'Pescadero V1 (Sushiswap ETH-AMPL)',
     address: '0x0000000000000000000000000000000000000000',
     stakingToken: StakingToken.SUSHISWAP,
+    rewardToken: RewardToken.AMPL,
     platformTokenConfigs: [],
     // staking token / pool address: 0xCb2286d9471cc185281c4f763d34A962ED212962
   },
@@ -22,6 +36,7 @@ const mainnetGeyserConfigs: GeyserConfig[] = [
     name: 'Beehive V3 (Uniswap ETH-AMPL)',
     address: '0x0000000000000000000000000000000000000000',
     stakingToken: StakingToken.UNISWAP_V2,
+    rewardToken: RewardToken.AMPL,
     platformTokenConfigs: [],
     // staking token / pool address: 0xc5be99A02C6857f9Eac67BbCE58DF5572498F40c
   },
@@ -29,6 +44,7 @@ const mainnetGeyserConfigs: GeyserConfig[] = [
     name: 'Trinity V1 (Balancer BTC-ETH-AMPL)',
     address: '0x0000000000000000000000000000000000000000',
     stakingToken: StakingToken.BALANCER_V1,
+    rewardToken: RewardToken.AMPL,
     platformTokenConfigs: [
       {
         address: '0xba100000625a3754423978a60c9317c58a424e3d',
@@ -41,6 +57,7 @@ const mainnetGeyserConfigs: GeyserConfig[] = [
     name: 'Old Faithful V1 (Balancer AMPL-USDC)',
     address: '0x0000000000000000000000000000000000000000',
     stakingToken: StakingToken.BALANCER_SMART_POOL_V1,
+    rewardToken: RewardToken.AMPL,
     platformTokenConfigs: [
       {
         address: '0xba100000625a3754423978a60c9317c58a424e3d',

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,17 +1,23 @@
 const MS_PER_SEC = 1000
 
-export const HOUR_IN_SEC = 3600
+export const MIN_IN_SEC = 60
+export const HOUR_IN_SEC = 60 * MIN_IN_SEC
 export const DAY_IN_SEC = 24 * HOUR_IN_SEC
 export const YEAR_IN_SEC = 365 * DAY_IN_SEC
 
+export const MIN_IN_MS = MIN_IN_SEC * MS_PER_SEC
 export const HOUR_IN_MS = HOUR_IN_SEC * MS_PER_SEC
 export const DAY_IN_MS = DAY_IN_SEC * MS_PER_SEC
 export const YEAR_IN_MS = YEAR_IN_SEC * MS_PER_SEC
 
+// polling interval for querying subgraph
 export const POLL_INTERVAL = 5 * MS_PER_SEC
 
 // pseudo permanent cache time
 export const CONST_CACHE_TIME_MS = YEAR_IN_MS
+
+// geyser stats cache time
+export const GEYSER_STATS_CACHE_TIME_MS = MIN_IN_SEC
 
 export const MOCK_ERC_20_ADDRESS = '0x0165878A594ca255338adfa4d48449f69242Eb8F'
 
@@ -27,3 +33,18 @@ export enum StakingToken {
   BALANCER_V1,
   BALANCER_SMART_POOL_V1,
 }
+
+// Reward tokens
+export enum RewardToken {
+  // for testing
+  MOCK,
+
+  // for mainnet
+  AMPL,
+}
+
+// ufragments deploy block number
+export const UFRG_INIT_BLOCK = 7947823
+
+export const AMPL_LAUNCH_DATE = 1561687200
+export const INITIAL_SUPPLY = 50000000

--- a/frontend/src/context/StatsContext.tsx
+++ b/frontend/src/context/StatsContext.tsx
@@ -4,7 +4,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react'
 import { toChecksumAddress } from 'web3-utils'
 import { getCurrentStakeReward } from '../sdk/stats'
 import { GeyserStats, UserStats, VaultStats } from '../types'
-import { defaultGeyserStats, defaultUserStats, defaultVaultStats, getGeyserStats, getUserStats, getVaultStats } from '../utils/stats'
+import { defaultGeyserStats, defaultUserStats, defaultVaultStats, getGeyserStats, getStakeDrip, getUserAPY, getUserDrip, getUserStats, getVaultStats } from '../utils/stats'
 import { GeyserContext } from './GeyserContext'
 import { VaultContext } from './VaultContext'
 import Web3Context from './Web3Context'
@@ -14,11 +14,15 @@ export const StatsContext = createContext<{
   geyserStats: GeyserStats
   vaultStats: VaultStats
   computeRewardsFromUnstake: (unstakeAmount: BigNumberish) => Promise<number>
+  computeAPYFromAdditionalStakes: (stakeAmount: BigNumberish) => Promise<number>
+  computeRewardsFromAdditionalStakes: (stakeAmount: BigNumberish) => Promise<number>
 }>({
   userStats: defaultUserStats(),
   geyserStats: defaultGeyserStats(),
   vaultStats: defaultVaultStats(),
   computeRewardsFromUnstake: async () => 0,
+  computeAPYFromAdditionalStakes: async () => 0,
+  computeRewardsFromAdditionalStakes: async () => 0,
 })
 
 export const StatsContextProvider: React.FC = ({ children }) => {
@@ -26,7 +30,7 @@ export const StatsContextProvider: React.FC = ({ children }) => {
   const [geyserStats, setGeyserStats] = useState<GeyserStats>(defaultGeyserStats())
   const [vaultStats, setVaultStats] = useState<VaultStats>(defaultVaultStats())
 
-  const { signer } = useContext(Web3Context)
+  const { signer, defaultProvider } = useContext(Web3Context)
   const { selectedGeyser, rewardTokenInfo, stakingTokenInfo, platformTokenInfos } = useContext(GeyserContext)
   const { selectedVault, currentLock } = useContext(VaultContext)
 
@@ -41,14 +45,32 @@ export const StatsContextProvider: React.FC = ({ children }) => {
     return 0
   }
 
+  const computeAPYFromAdditionalStakes = async (stakeAmount: BigNumberish) => {
+    if (selectedGeyser && currentLock && signer) {
+      return getUserAPY(selectedGeyser, currentLock, stakingTokenInfo, rewardTokenInfo, stakeAmount, signer)
+    }
+    return 0
+  }
+
+  const computeRewardsFromAdditionalStakes = async (stakeAmount: BigNumberish) => {
+    const { decimals } = rewardTokenInfo
+    if (selectedGeyser && geyserStats.duration && signer) {
+      const drip = await (currentLock
+        ? getUserDrip(selectedGeyser, currentLock, stakeAmount, geyserStats.duration, signer)
+        : getStakeDrip(selectedGeyser, stakeAmount, geyserStats.duration, signer))
+      return parseFloat(formatUnits(drip, decimals))
+    }
+    return 0
+  }
+
   useEffect(() => {
     let mounted = true
     ;(async () => {
       try {
-        if (signer && selectedGeyser) {
+        if (selectedGeyser && stakingTokenInfo.address && rewardTokenInfo.address) {
           const newGeyserStats = await getGeyserStats(selectedGeyser, stakingTokenInfo, rewardTokenInfo)
-          const newUserStats = await getUserStats(selectedGeyser, selectedVault, currentLock, stakingTokenInfo, rewardTokenInfo, signer)
-          const newVaultStats = await getVaultStats(stakingTokenInfo, platformTokenInfos, rewardTokenInfo, selectedVault, currentLock, signer)
+          const newUserStats = await getUserStats(selectedGeyser, selectedVault, currentLock, stakingTokenInfo, rewardTokenInfo, signer || defaultProvider)
+          const newVaultStats = await getVaultStats(stakingTokenInfo, platformTokenInfos, rewardTokenInfo, selectedVault, currentLock, signer || defaultProvider)
           if (mounted) {
             setGeyserStats(newGeyserStats)
             setUserStats(newUserStats)
@@ -60,10 +82,19 @@ export const StatsContextProvider: React.FC = ({ children }) => {
       }
     })()
     return () => { mounted = false }
-  }, [signer, selectedGeyser, selectedVault, currentLock])
+  }, [selectedGeyser, selectedVault, currentLock, stakingTokenInfo.address, rewardTokenInfo.address])
 
   return (
-    <StatsContext.Provider value={{ userStats, geyserStats, vaultStats, computeRewardsFromUnstake }}>
+    <StatsContext.Provider
+      value={{
+        userStats,
+        geyserStats,
+        vaultStats,
+        computeRewardsFromUnstake,
+        computeAPYFromAdditionalStakes,
+        computeRewardsFromAdditionalStakes,
+      }}
+    >
       {children}
     </StatsContext.Provider>
   )

--- a/frontend/src/context/VaultContext.tsx
+++ b/frontend/src/context/VaultContext.tsx
@@ -5,7 +5,7 @@ import { POLL_INTERVAL } from '../constants'
 import { Lock, Vault } from '../types'
 import Web3Context from './Web3Context'
 import { GeyserContext } from './GeyserContext'
-import { Centered } from 'styling/styles'
+import { Centered } from '../styling/styles'
 
 export const VaultContext = createContext<{
   vaults: Vault[]
@@ -21,27 +21,6 @@ export const VaultContext = createContext<{
   currentLock: null,
 })
 
-const mockVaults = [
-  {
-    id: '1',
-    nonce: '1',
-    claimedReward: [],
-    locks: [],
-  },
-  {
-    id: '2',
-    nonce: '1',
-    claimedReward: [],
-    locks: [],
-  },
-  {
-    id: '3',
-    nonce: '1',
-    claimedReward: [],
-    locks: [],
-  },
-]
-
 export const VaultContextProvider: React.FC = ({ children }) => {
   const { address } = useContext(Web3Context)
   const { selectedGeyser } = useContext(GeyserContext)
@@ -49,7 +28,7 @@ export const VaultContextProvider: React.FC = ({ children }) => {
     pollInterval: POLL_INTERVAL,
   })
 
-  const [vaults, setVaults] = useState<Vault[]>(mockVaults)
+  const [vaults, setVaults] = useState<Vault[]>([])
   const [selectedVault, setSelectedVault] = useState<Vault | null>(vaults ? vaults[0] : null)
   const [currentLock, setCurrentLock] = useState<Lock | null>(null)
 

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -29,9 +29,12 @@ export const WalletContextProvider: React.FC = ({ children }) => {
       }
     }
     return BigNumber.from('0')
-  }, [selectedGeyser, signer])
+  }, [selectedGeyser?.stakingToken, signer])
 
-  const refreshWalletAmount = () => getWalletAmount()
+  const refreshWalletAmount = async () => {
+    const balance = await getWalletAmount()
+    setWalletAmount(balance)
+  }
 
   useEffect(() => {
     // `mounted` is a workaround for supressing the warning saying that a state update on an unmounted

--- a/frontend/src/context/Web3Context.tsx
+++ b/frontend/src/context/Web3Context.tsx
@@ -1,15 +1,17 @@
 import { API, Wallet } from 'bnc-onboard/dist/src/interfaces'
 import Onboard from 'bnc-onboard'
 import React, { createContext, useCallback, useEffect, useState } from 'react'
-import { ethers, Signer } from 'ethers'
+import { providers, Signer } from 'ethers'
+import { getDefaultProvider } from '../utils/eth'
 
-class Provider extends ethers.providers.Web3Provider {}
+class Provider extends providers.Web3Provider {}
 
 const Web3Context = createContext<{
   address?: string
   wallet: Wallet | null
   onboard?: API
   provider: Provider | null
+  defaultProvider: providers.Provider
   signer?: Signer
   selectWallet: () => Promise<boolean>
   ready: boolean
@@ -18,6 +20,7 @@ const Web3Context = createContext<{
   ready: false,
   wallet: null,
   provider: null,
+  defaultProvider: getDefaultProvider(),
 })
 
 interface Subscriptions {
@@ -40,6 +43,7 @@ const Web3Provider: React.FC = ({ children }) => {
   const [wallet, setWallet] = useState<Wallet | null>(null)
   const [onboard, setOnboard] = useState<API>()
   const [provider, setProvider] = useState<Provider | null>(null)
+  const [defaultProvider] = useState<providers.Provider>(getDefaultProvider())
   const [signer, setSigner] = useState<Signer>()
   const [ready, setReady] = useState(false)
 
@@ -98,6 +102,7 @@ const Web3Provider: React.FC = ({ children }) => {
         signer,
         selectWallet,
         ready,
+        defaultProvider,
       }}
     >
       {children}

--- a/frontend/src/queries/geyser.ts
+++ b/frontend/src/queries/geyser.ts
@@ -17,8 +17,8 @@ export const GET_GEYSERS = gql`
         id
         duration
         start
+        rewardAmount
       }
-      totalRewardsClaimed
       lastUpdate
     }
   }

--- a/frontend/src/sdk/stats.ts
+++ b/frontend/src/sdk/stats.ts
@@ -1,43 +1,60 @@
-import { BigNumber, BigNumberish, Contract, Signer } from 'ethers'
+import { BigNumber, BigNumberish, Contract, providers, Signer } from 'ethers'
 import { loadNetworkConfig } from './utils'
 
 async function _execGeyserFunction<T>(
   geyserAddress: string,
-  signer: Signer,
+  signerOrProvider: Signer | providers.Provider,
   fnc: string,
   args: any[] = [],
 ): Promise<T> {
-  const config = await loadNetworkConfig(signer)
-  const geyser = new Contract(geyserAddress, config.GeyserTemplate.abi, signer)
+  const config = await loadNetworkConfig(signerOrProvider)
+  const geyser = new Contract(geyserAddress, config.GeyserTemplate.abi, signerOrProvider)
   return geyser[fnc](...args) as Promise<T>
 }
 
-export const getCurrentVaultReward = async (vaultAddress: string, geyserAddress: string, signer: Signer) => {
-  return _execGeyserFunction<BigNumber>(geyserAddress, signer, 'getCurrentVaultReward', [vaultAddress])
+export const getCurrentVaultReward = async (
+  vaultAddress: string,
+  geyserAddress: string,
+  signerOrProvider: Signer | providers.Provider,
+) => {
+  return _execGeyserFunction<BigNumber>(geyserAddress, signerOrProvider, 'getCurrentVaultReward', [vaultAddress])
 }
 
 export const getFutureVaultReward = async (
   vaultAddress: string,
   geyserAddress: string,
   timestamp: number,
-  signer: Signer,
+  signerOrProvider: Signer | providers.Provider,
 ) => {
-  return _execGeyserFunction<BigNumber>(geyserAddress, signer, 'getFutureVaultReward', [vaultAddress, timestamp])
+  return _execGeyserFunction<BigNumber>(geyserAddress, signerOrProvider, 'getFutureVaultReward', [
+    vaultAddress,
+    timestamp,
+  ])
 }
 
-export const getCurrentUnlockedRewards = async (geyserAddress: string, signer: Signer) => {
-  return _execGeyserFunction<BigNumber>(geyserAddress, signer, 'getCurrentUnlockedRewards')
+export const getCurrentUnlockedRewards = async (
+  geyserAddress: string,
+  signerOrProvider: Signer | providers.Provider,
+) => {
+  return _execGeyserFunction<BigNumber>(geyserAddress, signerOrProvider, 'getCurrentUnlockedRewards')
 }
 
-export const getFutureUnlockedRewards = async (geyserAddress: string, timestamp: number, signer: Signer) => {
-  return _execGeyserFunction<BigNumber>(geyserAddress, signer, 'getFutureUnlockedRewards', [timestamp])
+export const getFutureUnlockedRewards = async (
+  geyserAddress: string,
+  timestamp: number,
+  signerOrProvider: Signer | providers.Provider,
+) => {
+  return _execGeyserFunction<BigNumber>(geyserAddress, signerOrProvider, 'getFutureUnlockedRewards', [timestamp])
 }
 
 export const getCurrentStakeReward = async (
   vaultAddress: string,
   geyserAddress: string,
   amount: BigNumberish,
-  signer: Signer,
+  signerOrProvider: Signer | providers.Provider,
 ) => {
-  return _execGeyserFunction<BigNumber>(geyserAddress, signer, 'getCurrentStakeReward', [vaultAddress, amount])
+  return _execGeyserFunction<BigNumber>(geyserAddress, signerOrProvider, 'getCurrentStakeReward', [
+    vaultAddress,
+    amount,
+  ])
 }

--- a/frontend/src/sdk/tokens.ts
+++ b/frontend/src/sdk/tokens.ts
@@ -1,28 +1,32 @@
-import { BigNumber, Contract, Signer } from 'ethers'
-import { parseUnits } from 'ethers/lib/utils'
+import { BigNumber, Contract, providers, Signer } from 'ethers'
 import { ERC20_ABI } from './abis'
 
-function _execTokenFunction<T>(tokenAddress: string, signer: Signer, fnc: string, args: any[] = []): Promise<T> {
-  const token = new Contract(tokenAddress, ERC20_ABI, signer)
+function _execTokenFunction<T>(
+  tokenAddress: string,
+  signerOrProvider: Signer | providers.Provider,
+  fnc: string,
+  args: any[] = [],
+): Promise<T> {
+  const token = new Contract(tokenAddress, ERC20_ABI, signerOrProvider)
   return token[fnc](...args) as Promise<T>
 }
 
-export const ERC20Decimals = async (tokenAddress: string, signer: Signer) => {
-  return _execTokenFunction<number>(tokenAddress, signer, 'decimals')
+export const ERC20Decimals = async (tokenAddress: string, signerOrProvider: Signer | providers.Provider) => {
+  return _execTokenFunction<number>(tokenAddress, signerOrProvider, 'decimals')
 }
 
-export const ERC20Name = async (tokenAddress: string, signer: Signer) => {
-  return _execTokenFunction<string>(tokenAddress, signer, 'name')
+export const ERC20Name = async (tokenAddress: string, signerOrProvider: Signer | providers.Provider) => {
+  return _execTokenFunction<string>(tokenAddress, signerOrProvider, 'name')
 }
 
-export const ERC20Symbol = async (tokenAddress: string, signer: Signer) => {
-  return _execTokenFunction<string>(tokenAddress, signer, 'symbol')
+export const ERC20Symbol = async (tokenAddress: string, signerOrProvider: Signer | providers.Provider) => {
+  return _execTokenFunction<string>(tokenAddress, signerOrProvider, 'symbol')
 }
 
-export const ERC20Balance = async (tokenAddress: string, holderAddress: string, signer: Signer) => {
-  return _execTokenFunction<BigNumber>(tokenAddress, signer, 'balanceOf', [holderAddress])
-}
-
-export const parseUnitsWithDecimals = async (value: string, tokenAddress: string, signer: Signer) => {
-  return parseUnits(value, await ERC20Decimals(tokenAddress, signer))
+export const ERC20Balance = async (
+  tokenAddress: string,
+  holderAddress: string,
+  signerOrProvider: Signer | providers.Provider,
+) => {
+  return _execTokenFunction<BigNumber>(tokenAddress, signerOrProvider, 'balanceOf', [holderAddress])
 }

--- a/frontend/src/sdk/utils.ts
+++ b/frontend/src/sdk/utils.ts
@@ -1,12 +1,14 @@
 import { TypedDataField } from '@ethersproject/abstract-signer'
-import { BigNumberish, Contract, Signer, Wallet } from 'ethers'
+import { BigNumberish, Contract, providers, Signer, Wallet } from 'ethers'
 import { splitSignature } from 'ethers/lib/utils'
 import mainnetConfig from './deployments/mainnet/factories-latest.json'
 import goerliConfig from './deployments/goerli/factories-latest.json'
 import localhostConfig from './deployments/localhost/factories-latest.json'
 
-export const loadNetworkConfig = async (signer: Signer) => {
-  const network = await signer.provider?.getNetwork()
+export const loadNetworkConfig = async (signerOrProvider: Signer | providers.Provider) => {
+  const network = await (Signer.isSigner(signerOrProvider)
+    ? signerOrProvider.provider?.getNetwork()
+    : signerOrProvider.getNetwork())
 
   switch (network?.name) {
     case 'mainnet':

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,4 +1,5 @@
-import { StakingToken } from './constants'
+import { providers, Signer } from 'ethers'
+import { RewardToken, StakingToken } from './constants'
 
 type ClaimedReward = {
   id: string
@@ -24,6 +25,7 @@ export type RewardSchedule = {
   id: string
   duration: string
   start: string
+  rewardAmount: string
 }
 
 export type Geyser = {
@@ -38,7 +40,6 @@ export type Geyser = {
   scalingTime: string
   unlockedReward: string
   rewardSchedules: RewardSchedule[]
-  totalRewardsClaimed: string
   lastUpdate: string
 }
 
@@ -58,11 +59,7 @@ export type TokenInfo = {
   decimals: number
 }
 
-export type TokenComposition = {
-  address: string
-  name: string
-  symbol: string
-  decimals: number
+export type TokenComposition = TokenInfo & {
   balance: number
   value: number
   weight: number
@@ -75,10 +72,14 @@ export type StakingTokenInfo = TokenInfo & {
   composition: TokenComposition[]
 }
 
+export type RewardTokenInfo = TokenInfo & {
+  getTotalRewards: (rewardSchedules: RewardSchedule[]) => Promise<number>
+}
+
 export type GeyserStats = {
   duration: number
   totalDeposit: number
-  totalRewardsClaimed: number
+  totalRewards: number
 }
 
 export type VaultStats = {
@@ -99,6 +100,7 @@ export type GeyserConfig = {
   name: string
   address: string
   stakingToken: StakingToken
+  rewardToken: RewardToken
   platformTokenConfigs: PlatformTokenConfig[]
 }
 
@@ -106,3 +108,11 @@ export type PlatformTokenConfig = {
   address: string
   claimLink?: string
 }
+
+export type SupplyInfo = {
+  timestamp: number
+  supply: number
+  epoch: number
+}
+
+export type SignerOrProvider = Signer | providers.Provider

--- a/frontend/src/utils/ampleforth.ts
+++ b/frontend/src/utils/ampleforth.ts
@@ -1,0 +1,61 @@
+import { Contract } from 'ethers'
+import { formatUnits } from 'ethers/lib/utils'
+import { toChecksumAddress } from 'web3-utils'
+import { AMPL_LAUNCH_DATE, DAY_IN_MS, INITIAL_SUPPLY } from '../constants'
+import { RewardSchedule, SignerOrProvider, SupplyInfo } from '../types'
+import { UFRAGMENTS_POLICY_ABI } from './abis/UFragmentsPolicy'
+import { loadHistoricalLogs } from './eth'
+import * as ls from './cache'
+
+export const getTotalRewardShares = async (
+  rewardSchedules: RewardSchedule[],
+  policyAddress: string,
+  epoch: number,
+  decimals: number,
+  signerOrProvider: SignerOrProvider,
+) => {
+  const supplyHistory = await getSupplyHistory(policyAddress, epoch, decimals, signerOrProvider)
+  const getShares = (schedule: RewardSchedule) =>
+    parseFloat(formatUnits(schedule.rewardAmount, decimals)) / getSupplyOn(parseInt(schedule.start, 10), supplyHistory)
+  return rewardSchedules.reduce((acc, schedule) => acc + getShares(schedule), 0)
+}
+
+export const getSupplyOn = (timestamp: number, supplyHistory: SupplyInfo[]) => {
+  if (supplyHistory.length === 0) return 0
+
+  let index = supplyHistory.findIndex(({ timestamp: ts }) => timestamp < ts)
+  if (index < 0) {
+    index = supplyHistory.length
+  }
+  return supplyHistory[Math.max(index - 1, 0)].supply
+}
+
+export const getSupplyHistory = async (
+  policyAddress: string,
+  epoch: number,
+  decimals: number,
+  signerOrProvider: SignerOrProvider,
+) =>
+  ls.computeAndCache<SupplyInfo[]>(
+    async () => {
+      const policy = new Contract(policyAddress, UFRAGMENTS_POLICY_ABI, signerOrProvider)
+      const eventLogs = await loadHistoricalLogs(policy, 'LogRebase')
+      const historyFromLogs: SupplyInfo[] = eventLogs
+        .filter((log) => log.args)
+        .map((log) => ({
+          timestamp: parseInt(log.args!.timestampSec.toString(), 10),
+          supply: parseFloat(formatUnits(log.args!.requestedSupplyAdjustment, decimals)),
+          epoch: parseInt(log.args!.epoch, 10),
+        }))
+      const supplyHistory: SupplyInfo[] = [{ timestamp: AMPL_LAUNCH_DATE, supply: INITIAL_SUPPLY, epoch: 0 }].concat(
+        historyFromLogs,
+      )
+      for (let i = 1; i < supplyHistory.length; i++) {
+        supplyHistory[i].supply += supplyHistory[i - 1].supply
+      }
+      return supplyHistory
+    },
+    `${toChecksumAddress(policyAddress)}|supplyHistory`,
+    DAY_IN_MS,
+    (cached) => cached.length > 0 && cached[cached.length - 1].epoch >= epoch,
+  )

--- a/frontend/src/utils/cache.ts
+++ b/frontend/src/utils/cache.ts
@@ -15,3 +15,18 @@ export const get = (key: string): any => {
   }
   return null
 }
+
+// Returns the cached value if it exists and useCache(cachedValue) return true
+// Otherwise, compute the value, and cache it
+export async function computeAndCache<T>(
+  getValueOperation: () => Promise<T>,
+  key: string,
+  ttl: number,
+  useCache: (cached: T) => boolean = () => true,
+): Promise<T> {
+  const cachedValue = get(key)
+  if (cachedValue && useCache(cachedValue)) return cachedValue
+  const value = await getValueOperation()
+  set(key, value, ttl)
+  return value
+}

--- a/frontend/src/utils/eth.ts
+++ b/frontend/src/utils/eth.ts
@@ -1,0 +1,15 @@
+import { Contract, ethers } from 'ethers'
+import { UFRG_INIT_BLOCK } from '../constants'
+
+export const getDefaultProvider = () => {
+  if (process.env.NODE_ENV === 'development') {
+    return new ethers.providers.JsonRpcProvider('http://localhost:8545', { name: 'localhost', chainId: 1337 })
+  }
+  // TODO: pass infura api key as param
+  return ethers.getDefaultProvider()
+}
+
+export const loadHistoricalLogs = async (contract: Contract, eventName: string, startBlock = UFRG_INIT_BLOCK) => {
+  const filter = contract.filters[eventName]()
+  return contract.queryFilter(filter, startBlock, 'latest')
+}

--- a/frontend/src/utils/rewardToken.ts
+++ b/frontend/src/utils/rewardToken.ts
@@ -1,0 +1,67 @@
+import { Contract } from 'ethers'
+import { formatUnits } from 'ethers/lib/utils'
+import { RewardToken } from '../constants'
+import { RewardSchedule, RewardTokenInfo, SignerOrProvider } from '../types'
+import { UFRAGMENTS_ABI } from './abis/UFragments'
+import { UFRAGMENTS_POLICY_ABI } from './abis/UFragmentsPolicy'
+import { getTotalRewardShares } from './ampleforth'
+import { defaultTokenInfo, getTokenInfo } from './token'
+
+export const defaultRewardTokenInfo = (): RewardTokenInfo => ({
+  ...defaultTokenInfo(),
+  getTotalRewards: async () => 0,
+})
+
+export const getRewardTokenInfo = async (
+  tokenAddress: string,
+  token: RewardToken,
+  signerOrProvider: SignerOrProvider,
+) => {
+  switch (token) {
+    case RewardToken.MOCK:
+      return getMockToken(tokenAddress, signerOrProvider)
+    case RewardToken.AMPL:
+      return getAMPLToken(tokenAddress, signerOrProvider)
+    default:
+      throw new Error(`Handler for ${token} not found`)
+  }
+}
+
+const getMockToken = async (tokenAddress: string, signerOrProvider: SignerOrProvider): Promise<RewardTokenInfo> => {
+  const tokenInfo = await getTokenInfo(tokenAddress, signerOrProvider)
+  const getTotalRewards = async (rewardSchedules: RewardSchedule[]) =>
+    rewardSchedules.reduce(
+      (acc, schedule) => acc + parseFloat(formatUnits(schedule.rewardAmount, tokenInfo.decimals)),
+      0,
+    )
+  return {
+    ...tokenInfo,
+    getTotalRewards,
+  }
+}
+
+const getAMPLToken = async (tokenAddress: string, signerOrProvider: SignerOrProvider): Promise<RewardTokenInfo> => {
+  const contract = new Contract(tokenAddress, UFRAGMENTS_ABI, signerOrProvider)
+  const tokenInfo = await getTokenInfo(tokenAddress, signerOrProvider)
+  const policyAddress: string = await contract.monetaryPolicy()
+  const policy = new Contract(policyAddress, UFRAGMENTS_POLICY_ABI, signerOrProvider)
+
+  const totalSupply = await contract.totalSupply()
+  const epoch = parseInt(await policy.epoch(), 10)
+
+  const getTotalRewards = async (rewardSchedules: RewardSchedule[]) => {
+    const totalRewardShares = await getTotalRewardShares(
+      rewardSchedules,
+      policyAddress,
+      epoch,
+      tokenInfo.decimals,
+      signerOrProvider,
+    )
+    return totalRewardShares * totalSupply
+  }
+
+  return {
+    ...tokenInfo,
+    getTotalRewards,
+  }
+}

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -22,7 +22,6 @@ type Geyser @entity {
   lastUpdate: BigInt!
   rewardSchedules: [RewardSchedule]! @derivedFrom(field: "geyser")
   locks: [Lock]! @derivedFrom(field: "geyser")
-  totalRewardsClaimed: BigInt!
 }
 
 type User @entity {

--- a/subgraph/src/geyser.ts
+++ b/subgraph/src/geyser.ts
@@ -79,7 +79,6 @@ export function handleGeyserCreated(event: GeyserCreated): void {
   entity.scalingTime = geyserData.rewardScaling.time
   entity.status = 'Online'
   entity.bonusTokens = []
-  entity.totalRewardsClaimed = BigInt.fromI32(0)
 
   _updateGeyser(entity, geyserContract, event.block.timestamp)
 }
@@ -158,9 +157,6 @@ export function handleRewardClaimed(event: RewardClaimed): void {
   entity.amount = entity.amount.plus(event.params.amount)
   entity.lastUpdate = event.block.timestamp
 
-  let geyser = Geyser.load(event.address.toHex()) as Geyser
-  geyser.totalRewardsClaimed = geyser.totalRewardsClaimed.plus(event.params.amount)
-  geyser.save()
   updateGeyser(event.address, event.block.timestamp)
 
   entity.save()


### PR DESCRIPTION
## Stats Functions
We want to be able to compute the estimated rewards and estimated APY of a vault as the user inputs their desired stakes. Two functions to compute those were included in the `StatsContext`.

## Total Rewards
In this [previous PR](https://github.com/hyplabs/token-geyser-v2/pull/14), a field to the subgraph was added to keep track of `totalRewards`. However, it will not work if the token is a rebase token (i.e. AMPL). This PR reverts the subgraph changes, and instead uses historical logs scanning (same logic as V1) to calculate the total rewards.

## Default Provider
Added a default provider, which will be used to call contract functions that do not require transactions. This enables users to view geyser stats without having to connect their wallet (V1 behaviour)

## Caching
Geyser stats will be cached, can be changed under `constants.ts`, now set to 1 minute. User specific stats will not be cached, but we can look into caching them too if there's such need.