### PR TITLE
Transaction modal

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -10,7 +10,7 @@ interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   isLoading?: boolean
 }
 
-export const LoadingButton: React.FC<Props> = (props) => {
+export const Button: React.FC<Props> = (props) => {
   const { isLoading, children } = props
   return (
     <button type="button" {...props}>

--- a/frontend/src/components/EtherscanLink.tsx
+++ b/frontend/src/components/EtherscanLink.tsx
@@ -1,0 +1,9 @@
+import { EXTERNAL_LINKS } from "../constants";
+
+interface Props {
+  txHash?: string
+}
+
+export const EtherscanLink: React.FC<Props> = ({ txHash }) => (
+  <a rel="noreferrer" className="text-link" href={`${EXTERNAL_LINKS.etherscan}/${txHash}`} target="_blank">Etherscan</a>
+)

--- a/frontend/src/components/GeyserFirstContainer.tsx
+++ b/frontend/src/components/GeyserFirstContainer.tsx
@@ -1,10 +1,10 @@
 import React, { useContext } from 'react'
 import styled from 'styled-components/macro'
-import { GeyserStakeView } from './GeyserStakeView'
-import { Overlay } from '../styling/styles'
-import { ToggleView } from './ToggleView'
 import tw from 'twin.macro'
-import { GeyserContext } from '../context/GeyserContext'
+import { Overlay } from 'styling/styles'
+import { GeyserContext } from 'context/GeyserContext'
+import { ToggleView } from './ToggleView'
+import { GeyserStakeView } from './GeyserStakeView'
 import { GeyserStatsView } from './GeyserStatsView'
 
 interface Props {}

--- a/frontend/src/components/GeyserInteractionButton.tsx
+++ b/frontend/src/components/GeyserInteractionButton.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components/macro'
 import tw from 'twin.macro'
 
 interface Props {
-  onClick: () => {}
+  onClick: () => void
   displayText: string
   disabled?: boolean
 }

--- a/frontend/src/components/GeyserStakeView.tsx
+++ b/frontend/src/components/GeyserStakeView.tsx
@@ -1,7 +1,6 @@
 import { BigNumber } from 'ethers'
-import { parseUnits } from 'ethers/lib/utils'
-import React, { useContext, useEffect, useState } from 'react'
-import { TransactionReceipt } from '@ethersproject/providers'
+import { formatUnits, parseUnits } from 'ethers/lib/utils'
+import { useContext, useEffect, useState } from 'react'
 import { GeyserContext } from '../context/GeyserContext'
 import { VaultContext } from '../context/VaultContext'
 import { WalletContext } from '../context/WalletContext'
@@ -16,21 +15,29 @@ import { EstimatedRewards } from './EstimatedRewards'
 import { ConnectWalletWarning } from './ConnectWalletWarning'
 import { UnstakeSummary } from './UnstakeSummary'
 import { UnstakeConfirmModal } from './UnstakeConfirmModal'
+import { SingleTxModal } from './SingleTxModal'
+import { TransactionReceipt } from '@ethersproject/providers'
+import { UnstakeTxModal } from './UnstakeTxModal'
+import { TxStateMachine } from 'hooks/useTxStateMachine'
+import { TxState } from '../constants'
 
 interface Props {}
 
 export const GeyserStakeView: React.FC<Props> = () => {
   const [userInput, setUserInput] = useState('')
   const [parsedUserInput, setParsedUserInput] = useState(BigNumber.from('0'))
-  const [receipt, setReceipt] = useState<TransactionReceipt>()
-  const { selectedGeyser, stakingTokenInfo, handleGeyserAction, isStakingAction } = useContext(GeyserContext)
-  const { decimals: stakingTokenDecimals, symbol: stakingTokenSymbol } = stakingTokenInfo
+  const { selectedGeyser, stakingTokenInfo, rewardTokenInfo, handleGeyserAction, isStakingAction } = useContext(GeyserContext)
+  const { decimals: stakingTokenDecimals, symbol: stakingTokenSymbol, address: stakingTokenAddress } = stakingTokenInfo
+  const { decimals: rewardTokenDecimals, symbol: rewardTokenSymbol } = rewardTokenInfo
   const { signer } = useContext(Web3Context)
-  const { selectedVault, currentLock } = useContext(VaultContext)
+  const { selectedVault, currentLock, withdrawFromVault, withdrawRewardsFromVault } = useContext(VaultContext)
   const { walletAmount, refreshWalletAmount } = useContext(WalletContext)
   const { selectWallet, address } = useContext(Web3Context)
   const currentStakeAmount = BigNumber.from(currentLock ? currentLock.amount : '0')
   const [unstakeConfirmModalOpen, setUnstakeConfirmModalOpen] = useState<boolean>(false)
+  const [actualRewardsFromUnstake, setActualRewardsFromUnstake] = useState<BigNumber>(BigNumber.from('0'))
+
+  const [txModalOpen, setTxModalOpen] = useState<boolean>(false)
 
   const refreshInputAmount = () => {
     setUserInput('')
@@ -39,30 +46,106 @@ export const GeyserStakeView: React.FC<Props> = () => {
 
   useEffect(() => {
     refreshInputAmount()
-    refreshWalletAmount()
-  }, [receipt])
-
-  useEffect(() => {
-    refreshInputAmount()
   }, [isStakingAction])
 
-  const handleGeyserInteraction = async () => {
-    if (isStakingAction) {
-      setReceipt(await handleGeyserAction(selectedVault, parsedUserInput))
-    } else {
-      setUnstakeConfirmModalOpen(true)
-    }
+  const handleGeyserInteraction = () => {
+    (isStakingAction ? setTxModalOpen : setUnstakeConfirmModalOpen)(true)
   }
 
-  const handleConfirmUnstake = async () => {
-    setReceipt(await handleGeyserAction(selectedVault, parsedUserInput))
+  const handleConfirmUnstake = () => {
     setUnstakeConfirmModalOpen(false)
+
+    // Need to set a timeout before opening a new modal
+    // otherwise the overflow-y of the page gets messed up
+    setTimeout(() => setTxModalOpen(true), 500)
   }
 
   const handleOnChange = (value: string) => {
     setUserInput(value)
     if (selectedGeyser && signer) {
       setParsedUserInput(parseUnits(amountOrZero(value).toString(), stakingTokenDecimals))
+    }
+  }
+
+  const onCloseTxModal = () => {
+    setTxModalOpen(false)
+    refreshInputAmount()
+    refreshWalletAmount()
+  }
+
+  const withdrawStaking = async () => {
+    if (withdrawFromVault)
+      return withdrawFromVault(stakingTokenAddress, parsedUserInput)
+  }
+
+  const withdrawReward = async (receipt?: TransactionReceipt) => {
+    if (receipt && withdrawRewardsFromVault) {
+      const tx = await withdrawRewardsFromVault(receipt)
+      if (tx) {
+        const { response, rewards } = tx
+        setActualRewardsFromUnstake(rewards)
+        return response
+      }
+    }
+  }
+
+  const withdrawStakingTxMessage = (txStateMachine: TxStateMachine) => {
+    const { state, response } = txStateMachine
+    switch (state) {
+      case TxState.PENDING:
+        return <span>Withdrawing {stakingTokenSymbol} from your vault...</span>
+      case TxState.SUBMITTED:
+        return (
+          <span>
+            Withdrawing {stakingTokenSymbol} from your vault...{' '}
+            View on <a className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
+          </span>
+        )
+      case TxState.MINED:
+        return (
+          <span>
+            Successfully withdrew <b>{userInput} {stakingTokenSymbol}</b> from your vault to your wallet.{' '}
+            View on <a className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
+          </span>
+        )
+      case TxState.FAILED:
+        return (
+          <span>
+            Unlocked <b>{userInput} {stakingTokenSymbol}</b> that can be withdrawn from your vault.
+          </span>
+        )
+      default:
+        return <></>
+    }
+  }
+
+  const withdrawRewardTxMessage = (txStateMachine: TxStateMachine) => {
+    const { state, response } = txStateMachine
+    switch (state) {
+      case TxState.PENDING:
+        return <span>Withdrawing {rewardTokenSymbol} from your vault...</span>
+      case TxState.SUBMITTED:
+        return (
+          <span>
+            Withdrawing {rewardTokenSymbol} from your vault...{' '}
+            View on <a className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
+          </span>
+        )
+      case TxState.MINED:
+        return (
+          <span>
+            Successfully withdrew <b>{formatUnits(actualRewardsFromUnstake, rewardTokenDecimals)} {rewardTokenSymbol}</b> from your vault to your wallet.{' '}
+            View on <a className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
+          </span>
+        )
+      case TxState.FAILED:
+        return (
+          <span>
+            Unlocked <b>{formatUnits(actualRewardsFromUnstake, rewardTokenDecimals)} {rewardTokenSymbol}</b> that can be withdrawn from your vault.
+          </span>
+        )
+      default:
+        return <></>
     }
   }
 
@@ -91,7 +174,33 @@ export const GeyserStakeView: React.FC<Props> = () => {
         onClick={handleGeyserInteraction}
         displayText={isStakingAction ? `Stake` : `Unstake`}
       />
-      {!isStakingAction && <UnstakeConfirmModal parsedUserInput={parsedUserInput} open={unstakeConfirmModalOpen} onClose={() => setUnstakeConfirmModalOpen(false)} onConfirm={handleConfirmUnstake}/>}
+      {!isStakingAction && (
+        <UnstakeConfirmModal
+          parsedUserInput={parsedUserInput}
+          open={unstakeConfirmModalOpen}
+          onClose={() => setUnstakeConfirmModalOpen(false)}
+          onConfirm={handleConfirmUnstake}
+        />
+      )}
+      {isStakingAction ? (
+        <SingleTxModal
+          submit={() => handleGeyserAction(selectedVault, parsedUserInput)}
+          txSuccessMessage={<span>Successfully staked <b>{userInput} {stakingTokenSymbol}</b>.</span>}
+          open={txModalOpen}
+          onClose={onCloseTxModal}
+        />
+      ) : (
+        <UnstakeTxModal
+          open={txModalOpen}
+          unstake={() => handleGeyserAction(selectedVault, parsedUserInput)}
+          unstakeSuccessMessage={<span>Successfully unstaked <b>{userInput} {stakingTokenSymbol}</b>.</span>}
+          onClose={onCloseTxModal}
+          withdrawStaking={withdrawStaking}
+          withdrawStakingTxMessage={withdrawStakingTxMessage}
+          withdrawReward={withdrawReward}
+          withdrawRewardTxMessage={withdrawRewardTxMessage}
+        />
+      )}
     </GeyserStakeViewContainer>
   )
 }

--- a/frontend/src/components/GeyserStakeView.tsx
+++ b/frontend/src/components/GeyserStakeView.tsx
@@ -19,7 +19,7 @@ import { UnstakeSummary } from './UnstakeSummary'
 import { UnstakeConfirmModal } from './UnstakeConfirmModal'
 import { SingleTxModal } from './SingleTxModal'
 import { UnstakeTxModal } from './UnstakeTxModal'
-import { TxState } from '../constants'
+import { WithdrawTxMessage } from './WithdrawTxMessage'
 
 interface Props {}
 
@@ -57,7 +57,7 @@ export const GeyserStakeView: React.FC<Props> = () => {
 
     // Need to set a timeout before opening a new modal
     // otherwise the overflow-y of the page gets messed up
-    setTimeout(() => setTxModalOpen(true), 500)
+    setTimeout(() => setTxModalOpen(true), 300)
   }
 
   const handleOnChange = (value: string) => {
@@ -91,65 +91,13 @@ export const GeyserStakeView: React.FC<Props> = () => {
     return undefined
   }
 
-  const withdrawStakingTxMessage = (txStateMachine: TxStateMachine) => {
-    const { state, response } = txStateMachine
-    switch (state) {
-      case TxState.PENDING:
-        return <span>Withdrawing {stakingTokenSymbol} from your vault...</span>
-      case TxState.SUBMITTED:
-        return (
-          <span>
-            Withdrawing {stakingTokenSymbol} from your vault...{' '}
-            View on <a rel="noreferrer" className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
-          </span>
-        )
-      case TxState.MINED:
-        return (
-          <span>
-            Successfully withdrew <b>{userInput} {stakingTokenSymbol}</b> from your vault to your wallet.{' '}
-            View on <a rel="noreferrer" className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
-          </span>
-        )
-      case TxState.FAILED:
-        return (
-          <span>
-            Unlocked <b>{userInput} {stakingTokenSymbol}</b> that can be withdrawn from your vault.
-          </span>
-        )
-      default:
-        return <></>
-    }
-  }
+  const withdrawStakingTxMessage = (txStateMachine: TxStateMachine) => (
+    <WithdrawTxMessage txStateMachine={txStateMachine} symbol={stakingTokenSymbol} amount={userInput} />
+  )
 
-  const withdrawRewardTxMessage = (txStateMachine: TxStateMachine) => {
-    const { state, response } = txStateMachine
-    switch (state) {
-      case TxState.PENDING:
-        return <span>Withdrawing {rewardTokenSymbol} from your vault...</span>
-      case TxState.SUBMITTED:
-        return (
-          <span>
-            Withdrawing {rewardTokenSymbol} from your vault...{' '}
-            View on <a rel="noreferrer" className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
-          </span>
-        )
-      case TxState.MINED:
-        return (
-          <span>
-            Successfully withdrew <b>{formatUnits(actualRewardsFromUnstake, rewardTokenDecimals)} {rewardTokenSymbol}</b> from your vault to your wallet.{' '}
-            View on <a rel="noreferrer" className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
-          </span>
-        )
-      case TxState.FAILED:
-        return (
-          <span>
-            Unlocked <b>{formatUnits(actualRewardsFromUnstake, rewardTokenDecimals)} {rewardTokenSymbol}</b> that can be withdrawn from your vault.
-          </span>
-        )
-      default:
-        return <></>
-    }
-  }
+  const withdrawRewardTxMessage = (txStateMachine: TxStateMachine) => (
+    <WithdrawTxMessage txStateMachine={txStateMachine} symbol={rewardTokenSymbol} amount={formatUnits(actualRewardsFromUnstake, rewardTokenDecimals)} />
+  )
 
   return (
     <GeyserStakeViewContainer>

--- a/frontend/src/components/GeyserStakeView.tsx
+++ b/frontend/src/components/GeyserStakeView.tsx
@@ -1,24 +1,24 @@
 import { BigNumber } from 'ethers'
 import { formatUnits, parseUnits } from 'ethers/lib/utils'
-import { useContext, useEffect, useState } from 'react'
-import { GeyserContext } from '../context/GeyserContext'
-import { VaultContext } from '../context/VaultContext'
-import { WalletContext } from '../context/WalletContext'
-import Web3Context from '../context/Web3Context'
-import { amountOrZero } from '../utils/amount'
-import { PositiveInput } from './PositiveInput'
-import { GeyserInteractionButton } from './GeyserInteractionButton'
+import { TransactionReceipt } from '@ethersproject/providers'
 import tw from 'twin.macro'
 import styled from 'styled-components/macro'
+import { useContext, useEffect, useState } from 'react'
+import { GeyserContext } from 'context/GeyserContext'
+import { VaultContext } from 'context/VaultContext'
+import { WalletContext } from 'context/WalletContext'
+import Web3Context from 'context/Web3Context'
+import { TxStateMachine } from 'hooks/useTxStateMachine'
+import { amountOrZero } from 'utils/amount'
+import { PositiveInput } from './PositiveInput'
+import { GeyserInteractionButton } from './GeyserInteractionButton'
 import { UserBalance } from './UserBalance'
 import { EstimatedRewards } from './EstimatedRewards'
 import { ConnectWalletWarning } from './ConnectWalletWarning'
 import { UnstakeSummary } from './UnstakeSummary'
 import { UnstakeConfirmModal } from './UnstakeConfirmModal'
 import { SingleTxModal } from './SingleTxModal'
-import { TransactionReceipt } from '@ethersproject/providers'
 import { UnstakeTxModal } from './UnstakeTxModal'
-import { TxStateMachine } from 'hooks/useTxStateMachine'
 import { TxState } from '../constants'
 
 interface Props {}
@@ -76,6 +76,7 @@ export const GeyserStakeView: React.FC<Props> = () => {
   const withdrawStaking = async () => {
     if (withdrawFromVault)
       return withdrawFromVault(stakingTokenAddress, parsedUserInput)
+    return undefined
   }
 
   const withdrawReward = async (receipt?: TransactionReceipt) => {
@@ -87,6 +88,7 @@ export const GeyserStakeView: React.FC<Props> = () => {
         return response
       }
     }
+    return undefined
   }
 
   const withdrawStakingTxMessage = (txStateMachine: TxStateMachine) => {
@@ -98,14 +100,14 @@ export const GeyserStakeView: React.FC<Props> = () => {
         return (
           <span>
             Withdrawing {stakingTokenSymbol} from your vault...{' '}
-            View on <a className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
+            View on <a rel="noreferrer" className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
           </span>
         )
       case TxState.MINED:
         return (
           <span>
             Successfully withdrew <b>{userInput} {stakingTokenSymbol}</b> from your vault to your wallet.{' '}
-            View on <a className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
+            View on <a rel="noreferrer" className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
           </span>
         )
       case TxState.FAILED:
@@ -128,14 +130,14 @@ export const GeyserStakeView: React.FC<Props> = () => {
         return (
           <span>
             Withdrawing {rewardTokenSymbol} from your vault...{' '}
-            View on <a className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
+            View on <a rel="noreferrer" className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
           </span>
         )
       case TxState.MINED:
         return (
           <span>
             Successfully withdrew <b>{formatUnits(actualRewardsFromUnstake, rewardTokenDecimals)} {rewardTokenSymbol}</b> from your vault to your wallet.{' '}
-            View on <a className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
+            View on <a rel="noreferrer" className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
           </span>
         )
       case TxState.FAILED:

--- a/frontend/src/components/GeyserStats.tsx
+++ b/frontend/src/components/GeyserStats.tsx
@@ -1,11 +1,11 @@
 import styled from 'styled-components/macro'
-import { ResponsiveText } from '../styling/styles'
 import tw from 'twin.macro'
-import { GeyserStatsBox } from './GeyserStatsBox'
 import { useContext } from 'react'
-import { StatsContext } from '../context/StatsContext'
-import { safeNumeral } from '../utils/numeral'
-import { GeyserContext } from '../context/GeyserContext'
+import { StatsContext } from 'context/StatsContext'
+import { safeNumeral } from 'utils/numeral'
+import { GeyserContext } from 'context/GeyserContext'
+import { ResponsiveText } from 'styling/styles'
+import { GeyserStatsBox } from './GeyserStatsBox'
 import { DAY_IN_SEC } from '../constants'
 
 export const GeyserStats = () => {

--- a/frontend/src/components/GeyserStatsView.tsx
+++ b/frontend/src/components/GeyserStatsView.tsx
@@ -3,14 +3,12 @@ import tw from 'twin.macro'
 import { MyStats } from './MyStats'
 import { GeyserStats } from './GeyserStats'
 
-export const GeyserStatsView = () => {
-  return (
-    <GeyserStatsContainer>
-      <MyStats />
-      <GeyserStats />
-    </GeyserStatsContainer>
-  )
-}
+export const GeyserStatsView = () => (
+  <GeyserStatsContainer>
+    <MyStats />
+    <GeyserStats />
+  </GeyserStatsContainer>
+)
 
 const GeyserStatsContainer = styled.div`
   ${tw`grid grid-cols-2 w-full h-280px`};

--- a/frontend/src/components/LoadingButton.tsx
+++ b/frontend/src/components/LoadingButton.tsx
@@ -1,0 +1,21 @@
+// put in a component instead of its own asset file, because we need tailwind classes
+const ButtonSpinner = () => (
+  <svg fill="none" className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" viewBox="0 0 24 24">
+    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+  </svg>
+)
+
+interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  isLoading?: boolean
+}
+
+export const LoadingButton: React.FC<Props> = (props) => {
+  const { isLoading, children } = props
+  return (
+    <button type="button" {...props}>
+      {isLoading && <ButtonSpinner />}
+      {children}
+    </button>
+  )
+}

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -3,6 +3,9 @@ import { createContext, Fragment, MutableRefObject, useRef } from 'react'
 import styled from 'styled-components/macro'
 import tw from 'twin.macro'
 
+// Modal needs a focusable element to function correctly.
+// Use a context to pass the ref object down to Modal.Body,
+// which will make the modal focus on Modal.Body, if given
 const ModalContext = createContext<{
   ref: MutableRefObject<null> | null
 }>({

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,0 +1,113 @@
+import { Dialog, Transition } from '@headlessui/react'
+import { createContext, Fragment, MutableRefObject, useRef } from 'react'
+import styled from 'styled-components/macro'
+import tw from 'twin.macro'
+
+const ModalContext = createContext<{
+  ref: MutableRefObject<null> | null
+}>({
+  ref: null
+})
+
+const Title: React.FC = ({ children }) => (
+  <Dialog.Title
+    as="h3"
+    className="text-lg font-medium leading-6 text-gray-900"
+  >
+    {children}
+  </Dialog.Title>
+)
+
+const Body: React.FC = ({ children }) => (
+  <ModalContext.Consumer>
+    {({ ref }) => (
+      <MessageContainer>
+        <Message ref={ref}>
+          {children}
+        </Message>
+      </MessageContainer>
+    )}
+  </ModalContext.Consumer>
+)
+
+const Footer: React.FC = ({ children }) => (
+  <FooterContainer>
+    {children}
+  </FooterContainer>
+)
+
+interface ModalSubComponents {
+  Title: React.FC
+  Body: React.FC
+  Footer: React.FC
+}
+
+interface Props {
+  onClose: () => void
+  open: boolean
+  initialFocus?: MutableRefObject<null>
+  disableClose?: boolean
+}
+
+const ModalRoot: React.FC<Props> = ({ open, onClose, disableClose, children, initialFocus }) => {
+  const ref = initialFocus ?? useRef(null)
+
+  return (
+    <ModalContext.Provider value={{ ref }}>
+      <Transition appear show={open} as={Fragment}>
+        <Dialog
+          as="div"
+          className="fixed inset-0 z-10 overflow-y-auto"
+          onClose={disableClose ? () => {} : onClose}
+          initialFocus={ref}
+        >
+          <Container>
+            <Dialog.Overlay className="fixed inset-0 bg-black opacity-30"/>
+            {/* This element is to trick the browser into centering the modal contents. */}
+            <span
+              className="inline-block h-screen align-middle"
+              aria-hidden="true"
+            >
+              &#8203;
+            </span>
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <ContentContainer>
+                {children}
+              </ContentContainer>
+            </Transition.Child>
+          </Container>
+        </Dialog>
+      </Transition>
+    </ModalContext.Provider>
+  )
+}
+
+export const Modal: React.FC<Props> & ModalSubComponents = Object.assign(ModalRoot, { Title, Body, Footer })
+
+const Container = styled.div`
+  ${tw`min-h-screen px-4 text-center`}
+`
+
+const ContentContainer = styled.div`
+  ${tw`inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl`}
+`
+
+const MessageContainer = styled.div`
+  ${tw`mt-2`}
+`
+
+const Message = styled.p`
+  ${tw`text-sm`}
+`
+
+const FooterContainer = styled.div`
+  ${tw`mt-8 flex justify-center`}
+`

--- a/frontend/src/components/MyStatsBox.tsx
+++ b/frontend/src/components/MyStatsBox.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components/macro'
 import tw from 'twin.macro'
-import { ResponsiveSubText, ResponsiveText } from '../styling/styles'
 import { useSpring, animated } from 'react-spring'
 import { useState } from 'react'
+import { ResponsiveSubText, ResponsiveText } from 'styling/styles'
 
 interface Props {
   name: string

--- a/frontend/src/components/ProcessingButton.tsx
+++ b/frontend/src/components/ProcessingButton.tsx
@@ -1,0 +1,21 @@
+import styled from "styled-components/macro"
+import { ModalButton } from "styling/styles"
+import tw from "twin.macro"
+
+const ButtonSpinner = () => (
+  <svg fill="none" className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" viewBox="0 0 24 24">
+    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+  </svg>
+)
+
+export const ProcessingButton = () => (
+  <DisabledButton disabled>
+    <ButtonSpinner />
+    Processing
+  </DisabledButton>
+)
+
+const DisabledButton = styled(ModalButton)`
+  ${tw`bg-lightGray cursor-not-allowed border-none text-white cursor-not-allowed`}
+`

--- a/frontend/src/components/ProcessingButton.tsx
+++ b/frontend/src/components/ProcessingButton.tsx
@@ -2,10 +2,11 @@ import styled from "styled-components/macro"
 import { ModalButton } from "styling/styles"
 import tw from "twin.macro"
 
+// put in a component instead of its own asset file, because we need tailwind classes
 const ButtonSpinner = () => (
   <svg fill="none" className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" viewBox="0 0 24 24">
-    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
   </svg>
 )
 

--- a/frontend/src/components/ProcessingButton.tsx
+++ b/frontend/src/components/ProcessingButton.tsx
@@ -1,7 +1,6 @@
 import styled from "styled-components/macro"
 import tw from "twin.macro"
-import { ModalButtonStyle } from "styling/styles"
-import { LoadingButton } from "./LoadingButton"
+import { ModalButton } from "styling/styles"
 
 
 export const ProcessingButton = () => (
@@ -10,7 +9,6 @@ export const ProcessingButton = () => (
   </DisabledButton>
 )
 
-const DisabledButton = styled(LoadingButton)`
-  ${ModalButtonStyle}
+const DisabledButton = styled(ModalButton)`
   ${tw`bg-lightGray cursor-not-allowed border-none text-white cursor-not-allowed`}
 `

--- a/frontend/src/components/ProcessingButton.tsx
+++ b/frontend/src/components/ProcessingButton.tsx
@@ -1,22 +1,16 @@
 import styled from "styled-components/macro"
-import { ModalButton } from "styling/styles"
 import tw from "twin.macro"
+import { ModalButtonStyle } from "styling/styles"
+import { LoadingButton } from "./LoadingButton"
 
-// put in a component instead of its own asset file, because we need tailwind classes
-const ButtonSpinner = () => (
-  <svg fill="none" className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" viewBox="0 0 24 24">
-    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-  </svg>
-)
 
 export const ProcessingButton = () => (
-  <DisabledButton disabled>
-    <ButtonSpinner />
+  <DisabledButton disabled isLoading>
     Processing
   </DisabledButton>
 )
 
-const DisabledButton = styled(ModalButton)`
+const DisabledButton = styled(LoadingButton)`
+  ${ModalButtonStyle}
   ${tw`bg-lightGray cursor-not-allowed border-none text-white cursor-not-allowed`}
 `

--- a/frontend/src/components/SingleTxMessage.tsx
+++ b/frontend/src/components/SingleTxMessage.tsx
@@ -1,0 +1,37 @@
+import { TxStateMachine } from "hooks/useTxStateMachine"
+import { ReactNode } from "react"
+import { TxState } from "../constants"
+import { EtherscanLink } from "./EtherscanLink"
+
+interface Props {
+  txStateMachine: TxStateMachine
+  successMessage: ReactNode
+}
+
+export const SingleTxMessage: React.FC<Props> = ({ txStateMachine: { state, response }, successMessage }) => {
+  const getTxMessage = () => {
+    switch(state) {
+      case TxState.PENDING:
+        return <span>Waiting for user to confirm transaction...</span>
+      case TxState.SUBMITTED:
+        return (
+          <span>
+            Transaction submitted to blockchain, waiting to be mined.{' '}
+            View on <EtherscanLink txHash={response?.hash} />
+          </span>
+        )
+      case TxState.MINED:
+        return (
+          <>
+            {successMessage}{' '}
+            <span>View on <EtherscanLink txHash={response?.hash} /></span>
+          </>
+        )
+      case TxState.FAILED:
+        return <>Transaction failed.</>
+      default:
+        return <></>
+    }
+  }
+  return getTxMessage()
+}

--- a/frontend/src/components/SingleTxModal.tsx
+++ b/frontend/src/components/SingleTxModal.tsx
@@ -1,0 +1,73 @@
+import { TransactionResponse } from "@ethersproject/providers"
+import { TxState } from "../constants"
+import { useTxStateMachine } from "hooks/useTxStateMachine"
+import { ReactNode, useEffect, useState } from "react"
+import { Modal } from "./Modal"
+import { ModalButton } from "styling/styles"
+import { ProcessingButton } from "./ProcessingButton"
+
+interface Props {
+  submit: () => Promise<TransactionResponse | undefined>
+  txSuccessMessage?: ReactNode
+  open: boolean
+  onClose: () => void
+}
+
+export const SingleTxModal: React.FC<Props> = ({ submit, txSuccessMessage, open, onClose, children }) => {
+  const { state, response, submitTx, refresh } = useTxStateMachine(submit)
+  const [successMessage, setSuccessMessage] = useState<ReactNode>(null)
+
+  useEffect(() => {
+    if (open) {
+      refresh()
+      setSuccessMessage(txSuccessMessage || null)
+      submitTx()
+    }
+  }, [open])
+
+  const getModalBody = () => {
+    switch(state) {
+      case TxState.PENDING:
+        return <span>Waiting for user to confirm transaction...</span>
+      case TxState.SUBMITTED:
+        return (
+          <span>
+            Transaction submitted to blockchain, waiting to be mined.{' '}
+            View on <a className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
+          </span>
+        )
+      case TxState.MINED:
+        return (
+          <>
+            {successMessage}{' '}
+            <span>View on <a className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a></span>
+          </>
+        )
+      case TxState.FAILED:
+        return <>Transaction failed.</>
+      default:
+        return <></>
+    }
+  }
+
+  const isProcessing = () => [TxState.PENDING, TxState.SUBMITTED].includes(state)
+
+  return (
+    <Modal onClose={onClose} open={open} disableClose={isProcessing()}>
+      <Modal.Title>
+        Processing Transaction
+      </Modal.Title>
+      <Modal.Body>
+        {getModalBody()}
+        {children}
+      </Modal.Body>
+      <Modal.Footer>
+        {isProcessing() ? (
+          <ProcessingButton />
+        ) : (
+          <ModalButton onClick={onClose}> Close </ModalButton>
+        )}
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/frontend/src/components/SingleTxModal.tsx
+++ b/frontend/src/components/SingleTxModal.tsx
@@ -5,6 +5,7 @@ import { ModalButton } from "styling/styles"
 import { Modal } from "./Modal"
 import { ProcessingButton } from "./ProcessingButton"
 import { TxState } from "../constants"
+import { SingleTxMessage } from "./SingleTxMessage"
 
 interface Props {
   submit: () => Promise<TransactionResponse | undefined>
@@ -14,7 +15,8 @@ interface Props {
 }
 
 export const SingleTxModal: React.FC<Props> = ({ submit, txSuccessMessage, open, onClose, children }) => {
-  const { state, response, submitTx, refresh } = useTxStateMachine(submit)
+  const txStateMachine = useTxStateMachine(submit)
+  const { state, submitTx, refresh } = txStateMachine
   const [successMessage, setSuccessMessage] = useState<ReactNode>(null)
 
   useEffect(() => {
@@ -25,31 +27,6 @@ export const SingleTxModal: React.FC<Props> = ({ submit, txSuccessMessage, open,
     }
   }, [open])
 
-  const getModalBody = () => {
-    switch(state) {
-      case TxState.PENDING:
-        return <span>Waiting for user to confirm transaction...</span>
-      case TxState.SUBMITTED:
-        return (
-          <span>
-            Transaction submitted to blockchain, waiting to be mined.{' '}
-            View on <a rel="noreferrer" className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
-          </span>
-        )
-      case TxState.MINED:
-        return (
-          <>
-            {successMessage}{' '}
-            <span>View on <a rel="noreferrer" className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a></span>
-          </>
-        )
-      case TxState.FAILED:
-        return <>Transaction failed.</>
-      default:
-        return <></>
-    }
-  }
-
   const isProcessing = () => [TxState.PENDING, TxState.SUBMITTED].includes(state)
 
   return (
@@ -58,7 +35,7 @@ export const SingleTxModal: React.FC<Props> = ({ submit, txSuccessMessage, open,
         Processing Transaction
       </Modal.Title>
       <Modal.Body>
-        {getModalBody()}
+        <SingleTxMessage successMessage={successMessage} txStateMachine={txStateMachine} />
         {children}
       </Modal.Body>
       <Modal.Footer>

--- a/frontend/src/components/SingleTxModal.tsx
+++ b/frontend/src/components/SingleTxModal.tsx
@@ -1,10 +1,10 @@
-import { TransactionResponse } from "@ethersproject/providers"
-import { TxState } from "../constants"
-import { useTxStateMachine } from "hooks/useTxStateMachine"
 import { ReactNode, useEffect, useState } from "react"
-import { Modal } from "./Modal"
+import { TransactionResponse } from "@ethersproject/providers"
+import { useTxStateMachine } from "hooks/useTxStateMachine"
 import { ModalButton } from "styling/styles"
+import { Modal } from "./Modal"
 import { ProcessingButton } from "./ProcessingButton"
+import { TxState } from "../constants"
 
 interface Props {
   submit: () => Promise<TransactionResponse | undefined>
@@ -33,14 +33,14 @@ export const SingleTxModal: React.FC<Props> = ({ submit, txSuccessMessage, open,
         return (
           <span>
             Transaction submitted to blockchain, waiting to be mined.{' '}
-            View on <a className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
+            View on <a rel="noreferrer" className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
           </span>
         )
       case TxState.MINED:
         return (
           <>
             {successMessage}{' '}
-            <span>View on <a className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a></span>
+            <span>View on <a rel="noreferrer" className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a></span>
           </>
         )
       case TxState.FAILED:

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -55,14 +55,11 @@ export const Table: React.FC<Props> = ({ columns, dataSource }) => {
         <TableBody>
           {rows.map((row, rowNumber) => (
             <tr key={dataSource[rowNumber].key}>
-              {row.map((cell, colNumber) => {
-                console.log(columns[colNumber])
-                return (
-                  <RowCell className={getAlignmentClass(columns[colNumber].textAlign || Align.LEFT)}>
-                    {cell}
-                  </RowCell>
-                )
-              })}
+              {row.map((cell, colNumber) => (
+                <RowCell key={colNumber} className={getAlignmentClass(columns[colNumber].textAlign || Align.LEFT)}>
+                  {cell}
+                </RowCell>
+              ))}
             </tr>
           ))}
         </TableBody>

--- a/frontend/src/components/Table.tsx
+++ b/frontend/src/components/Table.tsx
@@ -55,11 +55,14 @@ export const Table: React.FC<Props> = ({ columns, dataSource }) => {
         <TableBody>
           {rows.map((row, rowNumber) => (
             <tr key={dataSource[rowNumber].key}>
-              {row.map((cell, colNumber) => (
-                <RowCell key={colNumber} className={getAlignmentClass(columns[colNumber].textAlign || Align.LEFT)}>
-                  {cell}
-                </RowCell>
-              ))}
+              {row.map((cell, colNumber) => {
+                console.log(columns[colNumber])
+                return (
+                  <RowCell className={getAlignmentClass(columns[colNumber].textAlign || Align.LEFT)}>
+                    {cell}
+                  </RowCell>
+                )
+              })}
             </tr>
           ))}
         </TableBody>

--- a/frontend/src/components/UnstakeConfirmModal.tsx
+++ b/frontend/src/components/UnstakeConfirmModal.tsx
@@ -1,11 +1,12 @@
-import { Dialog, Transition } from '@headlessui/react'
 import { StatsContext } from '../context/StatsContext'
-import { Fragment, useContext, useEffect, useState } from 'react'
+import { useContext, useEffect, useRef, useState } from 'react'
 import { safeNumeral } from '../utils/numeral'
 import { GeyserContext } from 'context/GeyserContext'
 import styled from 'styled-components/macro'
 import tw from 'twin.macro'
 import { BigNumber } from 'ethers'
+import { Modal } from './Modal'
+import { ModalButton } from 'styling/styles'
 
 interface Props {
   open: boolean
@@ -26,86 +27,27 @@ export const UnstakeConfirmModal: React.FC<Props> = ({ parsedUserInput, open, on
   }, [parsedUserInput])
 
   return (
-    <Transition appear show={open} as={Fragment}>
-      <Dialog
-        as="div"
-        className="fixed inset-0 z-10 overflow-y-auto"
-        onClose={onClose}
-      >
-        <Container>
-          <Dialog.Overlay className="fixed inset-0 bg-black opacity-30" />
-          {/* This element is to trick the browser into centering the modal contents. */}
-          <span
-              className="inline-block h-screen align-middle"
-              aria-hidden="true"
-            >
-              &#8203;
-            </span>
-            <Transition.Child
-              as={Fragment}
-              enter="ease-out duration-300"
-              enterFrom="opacity-0 scale-95"
-              enterTo="opacity-100 scale-100"
-              leave="ease-in duration-200"
-              leaveFrom="opacity-100 scale-100"
-              leaveTo="opacity-0 scale-95"
-            >
-              <ContentContainer>
-                <Dialog.Title
-                  as="h3"
-                  className="text-lg font-medium leading-6 text-gray-900"
-                >
-                  Are you sure?
-                </Dialog.Title>
-                <MessageContainer>
-                  <Message>
-                    If you stayed deposited for 1 more month,
-                    you could be eligible for an additional&nbsp;
-                    <b>
-                      {loss}{' '}
-                      {symbol}
-                    </b>{' '}
-                    reward.
-                  </Message>
-                </MessageContainer>
-
-                <ButtonContainer>
-                  <Button className="mr-4" onClick={onClose}>No, Wait</Button>
-                  <ConfirmButton onClick={onConfirm}>Withdraw Anyway</ConfirmButton>
-                </ButtonContainer>
-              </ContentContainer>
-            </Transition.Child>
-          </Container>
-      </Dialog>
-    </Transition>
+    <Modal onClose={onClose} open={open}>
+      <Modal.Title>
+        Are you sure?
+      </Modal.Title>
+      <Modal.Body>
+        If you stayed deposited for 1 more month,{' '}
+        you could be eligible for an additional{' '}
+        <b>
+          {loss}{' '}
+          {symbol}
+        </b>{' '}
+        reward.
+      </Modal.Body>
+      <Modal.Footer>
+        <ModalButton className="mr-4" onClick={onClose}>No, Wait</ModalButton>
+        <ConfirmButton onClick={onConfirm}>Withdraw Anyway</ConfirmButton>
+      </Modal.Footer>
+    </Modal>
   )
 }
 
-const Container = styled.div`
-  ${tw`min-h-screen px-4 text-center`}
-`
-
-const ContentContainer = styled.div`
-  ${tw`inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl`}
-`
-
-const MessageContainer = styled.div`
-  ${tw`mt-2`}
-`
-
-const Message = styled.p`
-  ${tw`text-sm`}
-`
-
-const ButtonContainer = styled.div`
-  ${tw`mt-8 flex justify-center`}
-`
-
-const Button = styled.button`
-  width: 40%;
-  ${tw`inline-flex items-center justify-center px-4 py-2 text-sm font-medium border rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2`}
-`
-
-const ConfirmButton = styled(Button)`
+const ConfirmButton = styled(ModalButton)`
   ${tw`rounded-lg bg-primary text-secondary font-semibold`}
 `

--- a/frontend/src/components/UnstakeConfirmModal.tsx
+++ b/frontend/src/components/UnstakeConfirmModal.tsx
@@ -1,12 +1,12 @@
-import { StatsContext } from '../context/StatsContext'
-import { useContext, useEffect, useRef, useState } from 'react'
-import { safeNumeral } from '../utils/numeral'
+import { useContext, useEffect, useState } from 'react'
+import { safeNumeral } from 'utils/numeral'
+import { StatsContext } from 'context/StatsContext'
 import { GeyserContext } from 'context/GeyserContext'
 import styled from 'styled-components/macro'
 import tw from 'twin.macro'
 import { BigNumber } from 'ethers'
-import { Modal } from './Modal'
 import { ModalButton } from 'styling/styles'
+import { Modal } from './Modal'
 
 interface Props {
   open: boolean

--- a/frontend/src/components/UnstakeSummary.tsx
+++ b/frontend/src/components/UnstakeSummary.tsx
@@ -1,12 +1,12 @@
 import { useContext, useState, useEffect } from 'react'
 import styled from 'styled-components/macro'
 import tw from 'twin.macro'
-import { GeyserContext } from '../context/GeyserContext'
-import { StatsContext } from '../context/StatsContext'
-import { CardValue, CardLabel } from '../styling/styles'
-import { amountOrZero } from '../utils/amount'
-import { formatWithDecimals } from '../utils/numeral'
 import { BigNumber } from 'ethers'
+import { GeyserContext } from 'context/GeyserContext'
+import { StatsContext } from 'context/StatsContext'
+import { CardValue, CardLabel } from 'styling/styles'
+import { amountOrZero } from 'utils/amount'
+import { formatWithDecimals } from 'utils/numeral'
 
 interface Props {
   userInput: string

--- a/frontend/src/components/UnstakeTxModal.tsx
+++ b/frontend/src/components/UnstakeTxModal.tsx
@@ -5,12 +5,13 @@ import { ModalButton } from 'styling/styles'
 import { Modal } from './Modal'
 import { ProcessingButton } from './ProcessingButton'
 import { TxState } from '../constants'
+import { SingleTxMessage } from './SingleTxMessage'
 
 interface Props {
   open: boolean
   onClose: () => void
   unstake: () => Promise<TransactionResponse | undefined>
-  unstakeSuccessMessage?: ReactNode
+  unstakeSuccessMessage: ReactNode
 
   withdrawStaking: () => Promise<TransactionResponse | undefined>
   withdrawStakingTxMessage: (txStateMachine: TxStateMachine) => ReactNode
@@ -44,37 +45,12 @@ export const UnstakeTxModal: React.FC<Props> = ({ open, onClose, unstake, unstak
     }
   }, [unstakeTxStateMachine])
 
-  const getUnstakeTxMessage = () => {
-    const { state, response } = unstakeTxStateMachine
-    switch (state) {
-      case TxState.PENDING:
-        return <span>Waiting for user to confirm transaction...</span>
-      case TxState.SUBMITTED:
-        return (
-          <span>
-            Transaction submitted to blockchain, waiting to be mined.{' '}
-            View on <a rel="noreferrer" className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
-          </span>
-        )
-      case TxState.MINED:
-        return (
-          <>
-            {unstakeSuccessMessage}{' '}
-            <span>View on <a rel="noreferrer" className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a></span>
-          </>
-        )
-      case TxState.FAILED:
-        return <>Transaction failed.</>
-      default:
-        return <></>
-    }
-  }
-
   const getModalBody = () => {
-    if (unstakeTxStateMachine.state !== TxState.MINED) return getUnstakeTxMessage()
+    if (unstakeTxStateMachine.state !== TxState.MINED)
+      return <SingleTxMessage txStateMachine={unstakeTxStateMachine} successMessage={unstakeSuccessMessage} />
     return (
       <div className="flex flex-col space-y-2">
-        <div>{getUnstakeTxMessage()}</div>
+        <div><SingleTxMessage txStateMachine={unstakeTxStateMachine} successMessage={unstakeSuccessMessage} /></div>
         <div>{withdrawStakingTxMessage(withdrawStakeStateMachine)}</div>
         <div>{withdrawRewardTxMessage(withdrawRewardStateMachine)}</div>
       </div>

--- a/frontend/src/components/UnstakeTxModal.tsx
+++ b/frontend/src/components/UnstakeTxModal.tsx
@@ -1,10 +1,10 @@
 import { TransactionResponse, TransactionReceipt } from '@ethersproject/providers'
-import { TxState } from '../constants'
 import { useTxStateMachine, TxStateMachine } from 'hooks/useTxStateMachine'
 import { ReactNode, useEffect, useState } from 'react'
-import { Modal } from './Modal'
 import { ModalButton } from 'styling/styles'
+import { Modal } from './Modal'
 import { ProcessingButton } from './ProcessingButton'
+import { TxState } from '../constants'
 
 interface Props {
   open: boolean
@@ -53,14 +53,14 @@ export const UnstakeTxModal: React.FC<Props> = ({ open, onClose, unstake, unstak
         return (
           <span>
             Transaction submitted to blockchain, waiting to be mined.{' '}
-            View on <a className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
+            View on <a rel="noreferrer" className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a>
           </span>
         )
       case TxState.MINED:
         return (
           <>
             {unstakeSuccessMessage}{' '}
-            <span>View on <a className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a></span>
+            <span>View on <a rel="noreferrer" className="text-link" href={`https://etherscan.io/tx/${response?.hash}`} target="_blank">Etherscan</a></span>
           </>
         )
       case TxState.FAILED:

--- a/frontend/src/components/VaultBalanceView.tsx
+++ b/frontend/src/components/VaultBalanceView.tsx
@@ -3,10 +3,10 @@ import { useContext, useState } from "react"
 import styled from "styled-components/macro"
 import tw from "twin.macro"
 import { safeNumeral } from "utils/numeral"
-import { Column, Table } from "./Table"
 import { VaultTokenBalance } from "types"
 import { VaultContext } from "context/VaultContext"
 import { Align } from "../constants"
+import { Column, Table } from "./Table"
 import { SingleTxModal } from "./SingleTxModal"
 
 export const VaultBalanceView = () => {
@@ -17,8 +17,8 @@ export const VaultBalanceView = () => {
   const [tokenBalance, setTokenBalance] = useState<VaultTokenBalance>()
   const [modalOpen, setModalOpen] = useState<boolean>(false)
 
-  const confirmWithdraw = (tokenBalance: VaultTokenBalance) => {
-    setTokenBalance(tokenBalance)
+  const confirmWithdraw = (balance: VaultTokenBalance) => {
+    setTokenBalance(balance)
     setModalOpen(true)
   }
 
@@ -27,6 +27,7 @@ export const VaultBalanceView = () => {
       const { address, parsedUnlockedBalance } = tokenBalance
       return withdrawFromVault(address, parsedUnlockedBalance)
     }
+    return undefined
   }
 
   const onClose = () => {

--- a/frontend/src/components/VaultFirstContainer.tsx
+++ b/frontend/src/components/VaultFirstContainer.tsx
@@ -3,15 +3,13 @@ import { Overlay } from 'styling/styles'
 import tw from 'twin.macro'
 import { VaultBalanceView } from './VaultBalanceView'
 
-export const VaultFirstContainer = () => {
-  return (
-    <Container>
-      <Overlay>
-        <VaultBalanceView />
-      </Overlay>
-    </Container>
-  )
-}
+export const VaultFirstContainer = () => (
+  <Container>
+    <Overlay>
+      <VaultBalanceView />
+    </Overlay>
+  </Container>
+)
 
 const Container = styled.div`
   ${tw`text-center m-auto flex flex-wrap w-full flex-col`}

--- a/frontend/src/components/WithdrawTxMessage.tsx
+++ b/frontend/src/components/WithdrawTxMessage.tsx
@@ -1,0 +1,41 @@
+import { TxStateMachine } from "hooks/useTxStateMachine"
+import { TxState } from "../constants"
+import { EtherscanLink } from "./EtherscanLink"
+
+interface Props {
+  txStateMachine: TxStateMachine
+  symbol: string
+  amount: string
+}
+
+export const WithdrawTxMessage: React.FC<Props> = ({ txStateMachine: { state, response }, symbol, amount }) => {
+  const getTxMessage = () => {
+    switch (state) {
+      case TxState.PENDING:
+        return <span>Withdrawing {symbol} from your vault...</span>
+      case TxState.SUBMITTED:
+        return (
+          <span>
+            Withdrawing {symbol} from your vault...{' '}
+            View on <EtherscanLink txHash={response?.hash} />
+          </span>
+        )
+      case TxState.MINED:
+        return (
+          <span>
+            Successfully withdrew <b>{amount} {symbol}</b> from your vault to your wallet.{' '}
+            View on <EtherscanLink txHash={response?.hash} />
+          </span>
+        )
+      case TxState.FAILED:
+        return (
+          <span>
+            Unlocked <b>{amount} {symbol}</b> that can be withdrawn from your vault.
+          </span>
+        )
+      default:
+        return <></>
+    }
+  }
+  return getTxMessage()
+}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -33,6 +33,10 @@ export enum TxState {
   FAILED,
 }
 
+export const EXTERNAL_LINKS: Record<string, string> = {
+  etherscan: 'https://etherscan.io/tx',
+}
+
 // Staking tokens
 export enum StakingToken {
   // for testing

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -21,9 +21,17 @@ export const POLL_INTERVAL = 5 * MS_PER_SEC
 export const CONST_CACHE_TIME_MS = YEAR_IN_MS
 
 // geyser stats cache time
-export const GEYSER_STATS_CACHE_TIME_MS = MIN_IN_SEC
+export const GEYSER_STATS_CACHE_TIME_MS = MIN_IN_MS
 
 export const MOCK_ERC_20_ADDRESS = '0x0165878A594ca255338adfa4d48449f69242Eb8F'
+
+// transaction state
+export enum TxState {
+  PENDING,
+  SUBMITTED,
+  MINED,
+  FAILED,
+}
 
 // Staking tokens
 export enum StakingToken {

--- a/frontend/src/context/GeyserContext.tsx
+++ b/frontend/src/context/GeyserContext.tsx
@@ -3,17 +3,17 @@ import { createContext, useContext, useEffect, useState } from 'react'
 import { toChecksumAddress } from 'web3-utils'
 import { TransactionResponse } from '@ethersproject/providers'
 import { BigNumber, Wallet } from 'ethers'
-import { Geyser, StakingTokenInfo, TokenInfo, GeyserConfig, RewardTokenInfo, Vault } from '../types'
+import { Geyser, StakingTokenInfo, TokenInfo, GeyserConfig, RewardTokenInfo, Vault } from 'types'
+import {  getTokenInfo } from 'utils/token'
+import { geyserConfigs } from 'config/geyser'
+import { defaultStakingTokenInfo, getStakingTokenInfo } from 'utils/stakingToken'
+import { approveCreateDepositStake, approveDepositStake, unstake } from 'sdk'
+import { GET_GEYSERS } from 'queries/geyser'
+import { Centered } from 'styling/styles'
+import { defaultRewardTokenInfo, getRewardTokenInfo } from 'utils/rewardToken'
+import { additionalTokens } from 'config/additionalTokens'
 import Web3Context from './Web3Context'
 import { POLL_INTERVAL } from '../constants'
-import {  getTokenInfo } from '../utils/token'
-import { geyserConfigs } from '../config/geyser'
-import { defaultStakingTokenInfo, getStakingTokenInfo } from '../utils/stakingToken'
-import { approveCreateDepositStake, approveDepositStake, unstake } from '../sdk'
-import { GET_GEYSERS } from '../queries/geyser'
-import { Centered } from '../styling/styles'
-import { defaultRewardTokenInfo, getRewardTokenInfo } from '../utils/rewardToken'
-import { additionalTokens } from 'config/additionalTokens'
 
 export const GeyserContext = createContext<{
   geysers: Geyser[]
@@ -74,6 +74,7 @@ export const GeyserContextProvider: React.FC = ({ children }) => {
       const vaultAddress = selectedVault.id
       return unstake(geyserAddress, vaultAddress, parsedAmount, signer as Wallet)
     }
+    return undefined
   }
   const handleStake = async (selectedVault: Vault | null, parsedAmount: BigNumber) => {
     if (selectedGeyser && signer && !parsedAmount.isZero()) {
@@ -83,6 +84,7 @@ export const GeyserContextProvider: React.FC = ({ children }) => {
         : approveCreateDepositStake(geyserAddress, parsedAmount, signer as Wallet)
       )
     }
+    return undefined
   }
 
   const selectGeyser = (geyser: Geyser) => setSelectedGeyser(geyser)

--- a/frontend/src/context/StatsContext.tsx
+++ b/frontend/src/context/StatsContext.tsx
@@ -1,14 +1,14 @@
-import { MONTH_IN_SEC } from '../constants'
 import {  BigNumberish } from 'ethers'
 import { formatUnits } from 'ethers/lib/utils'
 import React, { createContext, useContext, useEffect, useState } from 'react'
 import { toChecksumAddress } from 'web3-utils'
-import { getCurrentStakeReward } from '../sdk/stats'
-import { GeyserStats, UserStats, VaultStats } from '../types'
-import { defaultGeyserStats, defaultUserStats, defaultVaultStats, getGeyserStats, getStakeDrip, getUserAPY, getUserDrip, getUserDripAfterWithdraw, getUserStats, getVaultStats } from '../utils/stats'
+import { getCurrentStakeReward } from 'sdk/stats'
+import { GeyserStats, UserStats, VaultStats } from 'types'
+import { defaultGeyserStats, defaultUserStats, defaultVaultStats, getGeyserStats, getStakeDrip, getUserAPY, getUserDrip, getUserDripAfterWithdraw, getUserStats, getVaultStats } from 'utils/stats'
 import { GeyserContext } from './GeyserContext'
 import { VaultContext } from './VaultContext'
 import Web3Context from './Web3Context'
+import { MONTH_IN_SEC } from '../constants'
 
 export const StatsContext = createContext<{
   userStats: UserStats

--- a/frontend/src/context/VaultContext.tsx
+++ b/frontend/src/context/VaultContext.tsx
@@ -1,14 +1,14 @@
 import { useLazyQuery } from '@apollo/client'
 import { createContext, useContext, useEffect, useState } from 'react'
+import { TransactionResponse, TransactionReceipt } from '@ethersproject/providers'
+import { BigNumber } from 'ethers'
+import { withdraw, withdrawRewards } from 'sdk'
 import { GET_USER_VAULTS } from '../queries/vault'
 import { POLL_INTERVAL } from '../constants'
 import { Lock, Vault } from '../types'
 import Web3Context from './Web3Context'
 import { GeyserContext } from './GeyserContext'
 import { Centered } from '../styling/styles'
-import { TransactionResponse, TransactionReceipt } from '@ethersproject/providers'
-import { BigNumber } from 'ethers'
-import { withdraw, withdrawRewards } from 'sdk'
 
 export const VaultContext = createContext<{
   vaults: Vault[]

--- a/frontend/src/context/VaultContext.tsx
+++ b/frontend/src/context/VaultContext.tsx
@@ -6,9 +6,9 @@ import { Lock, Vault } from '../types'
 import Web3Context from './Web3Context'
 import { GeyserContext } from './GeyserContext'
 import { Centered } from '../styling/styles'
-import { TransactionResponse } from '@ethersproject/providers'
+import { TransactionResponse, TransactionReceipt } from '@ethersproject/providers'
 import { BigNumber } from 'ethers'
-import { withdraw } from 'sdk'
+import { withdraw, withdrawRewards } from 'sdk'
 
 export const VaultContext = createContext<{
   vaults: Vault[]
@@ -17,6 +17,7 @@ export const VaultContext = createContext<{
   selectVaultById: (id: string) => void
   currentLock: Lock | null
   withdrawFromVault: ((tokenAddress: string, amount: BigNumber) => Promise<TransactionResponse>) | null
+  withdrawRewardsFromVault: ((receipt: TransactionReceipt) => Promise<{ response: TransactionResponse, rewards: BigNumber } | null>) | null
 }>({
   vaults: [],
   selectedVault: null,
@@ -24,10 +25,11 @@ export const VaultContext = createContext<{
   selectVaultById: () => {},
   currentLock: null,
   withdrawFromVault: null,
+  withdrawRewardsFromVault: null,
 })
 
 export const VaultContextProvider: React.FC = ({ children }) => {
-  const { address, signer } = useContext(Web3Context)
+  const { address, signer, ready } = useContext(Web3Context)
   const { selectedGeyser } = useContext(GeyserContext)
   const [getVaults, { loading: vaultLoading, data: vaultData }] = useLazyQuery(GET_USER_VAULTS, {
     pollInterval: POLL_INTERVAL,
@@ -41,6 +43,10 @@ export const VaultContextProvider: React.FC = ({ children }) => {
   const selectVaultById = (id: string) => setSelectedVault(vaults.find(vault => vault.id === id) || selectedVault)
   const withdrawFromVault = address && signer && selectedVault
     ? (tokenAddress: string, amount: BigNumber) => withdraw(selectedVault.id, tokenAddress, address, amount, signer)
+    : null
+
+  const withdrawRewardsFromVault = address && signer && selectedGeyser
+    ? (receipt: TransactionReceipt) => withdrawRewards(selectedGeyser.id, address, receipt, signer)
     : null
 
   useEffect(() => {
@@ -72,7 +78,7 @@ export const VaultContextProvider: React.FC = ({ children }) => {
     }
   }, [selectedVault, selectedGeyser])
 
-  if (vaultLoading) return <Centered>Loading...</Centered>
+  if (vaultLoading || (!address && ready)) return <Centered>Loading...</Centered>
 
   return (
     <VaultContext.Provider
@@ -83,6 +89,7 @@ export const VaultContextProvider: React.FC = ({ children }) => {
         selectVaultById,
         currentLock,
         withdrawFromVault,
+        withdrawRewardsFromVault,
       }}
     >
       {children}

--- a/frontend/src/hooks/useTxStateMachine.ts
+++ b/frontend/src/hooks/useTxStateMachine.ts
@@ -1,0 +1,57 @@
+import { TransactionResponse, TransactionReceipt } from '@ethersproject/providers'
+import { TxState } from '../constants'
+import { useEffect, useState } from 'react'
+
+type SubmitFunction = (receipt?: TransactionReceipt) => Promise<TransactionResponse | undefined>
+
+type CurrentTxState = {
+  state: TxState
+  response?: TransactionResponse
+  receipt?: TransactionReceipt
+}
+
+export type TxStateMachine = CurrentTxState & {
+  submitTx: (receipt?: TransactionReceipt) => Promise<void>
+  refresh: () => void
+}
+
+export const useTxStateMachine = (submit: SubmitFunction) => {
+  const [currentTxState, setCurrentTxState] = useState<CurrentTxState>({ state: TxState.PENDING })
+
+  useEffect(() => {
+    ;(async () => {
+      const { response } = currentTxState
+      try {
+        if (response) {
+          const receipt = await response.wait()
+          setCurrentTxState((txState) => ({ ...txState, receipt, state: TxState.MINED }))
+        }
+      } catch (e) {
+        setCurrentTxState((txState) => ({ ...txState, state: TxState.FAILED }))
+      }
+    })()
+  }, [currentTxState.response])
+
+  const submitTx = async (receipt?: TransactionReceipt) => {
+    try {
+      const response = await submit(receipt)
+      if (response) {
+        setCurrentTxState((txState) => ({ ...txState, response, state: TxState.SUBMITTED }))
+      } else {
+        setCurrentTxState((txState) => ({ ...txState, state: TxState.FAILED }))
+      }
+    } catch (e) {
+      setCurrentTxState((txState) => ({ ...txState, state: TxState.FAILED }))
+    }
+  }
+
+  const refresh = () => {
+    setCurrentTxState({ state: TxState.PENDING })
+  }
+
+  return {
+    submitTx,
+    refresh,
+    ...currentTxState,
+  }
+}

--- a/frontend/src/hooks/useTxStateMachine.ts
+++ b/frontend/src/hooks/useTxStateMachine.ts
@@ -1,6 +1,6 @@
+import { useEffect, useState } from 'react'
 import { TransactionResponse, TransactionReceipt } from '@ethersproject/providers'
 import { TxState } from '../constants'
-import { useEffect, useState } from 'react'
 
 type SubmitFunction = (receipt?: TransactionReceipt) => Promise<TransactionResponse | undefined>
 

--- a/frontend/src/sdk/stats.ts
+++ b/frontend/src/sdk/stats.ts
@@ -1,5 +1,6 @@
 import { BigNumber, BigNumberish, Contract, providers, Signer } from 'ethers'
-import { loadNetworkConfig } from './utils'
+import { TransactionReceipt } from '@ethersproject/providers'
+import { loadNetworkConfig, parseEventFromReceipt } from './utils'
 
 async function _execGeyserFunction<T>(
   geyserAddress: string,
@@ -76,4 +77,16 @@ export const getBalanceLocked = async (
   signerOrProvider: Signer | providers.Provider,
 ) => {
   return _execVaultFunction<BigNumber>(vaultAddress, signerOrProvider, 'getBalanceLocked', [tokenAddress])
+}
+
+export const getClaimedRewardsFromUnstake = async (
+  receipt: TransactionReceipt,
+  geyserAddress: string,
+  signerOrProvider: Signer | providers.Provider,
+) => {
+  const config = await loadNetworkConfig(signerOrProvider)
+  const geyser = new Contract(geyserAddress, config.GeyserTemplate.abi, signerOrProvider)
+  const eventLog = parseEventFromReceipt(receipt, geyser, 'RewardClaimed')
+  if (!eventLog) return null
+  return eventLog.args
 }

--- a/frontend/src/sdk/utils.ts
+++ b/frontend/src/sdk/utils.ts
@@ -107,6 +107,8 @@ export const signPermitEIP2612 = async (
   return [values.owner, values.spender, values.value, values.deadline, sig.v, sig.r, sig.s]
 }
 
+// utility function to parse an event from a transaction receipt
+// useful when we need to get data from a specific transaction (e.g. getting the actual rewards claimed from unstake)
 export const parseEventFromReceipt = (
   receipt: TransactionReceipt,
   contract: Contract,

--- a/frontend/src/styling/styles.ts
+++ b/frontend/src/styling/styles.ts
@@ -39,3 +39,8 @@ export const CardLabel = styled.span`
 export const CardValue = styled.span`
   ${tw`flex uppercase text-xl`}
 `
+
+export const ModalButton = styled.button`
+  width: 40%;
+  ${tw`inline-flex items-center justify-center px-4 py-2 text-sm font-medium border rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2`}
+`

--- a/frontend/src/styling/styles.ts
+++ b/frontend/src/styling/styles.ts
@@ -40,7 +40,12 @@ export const CardValue = styled.span`
   ${tw`flex uppercase text-xl`}
 `
 
-export const ModalButton = styled.button`
+export const ModalButtonStyle = css`
   width: 40%;
-  ${tw`inline-flex items-center justify-center px-4 py-2 text-sm font-medium border rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2`}
+  ${tw`inline-flex items-center justify-center px-4 py-2 text-sm font-medium border rounded-md`}
+  ${tw`focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2`}
+`
+
+export const ModalButton = styled.button`
+  ${ModalButtonStyle}
 `

--- a/frontend/src/styling/styles.ts
+++ b/frontend/src/styling/styles.ts
@@ -1,5 +1,6 @@
 import styled, { css } from 'styled-components/macro'
 import tw from 'twin.macro'
+import { Button } from 'components/Button'
 
 export const Paragraph = styled.p`
   color: ${(props) => props.color};
@@ -40,12 +41,8 @@ export const CardValue = styled.span`
   ${tw`flex uppercase text-xl`}
 `
 
-export const ModalButtonStyle = css`
+export const ModalButton = styled(Button)`
   width: 40%;
   ${tw`inline-flex items-center justify-center px-4 py-2 text-sm font-medium border rounded-md`}
   ${tw`focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2`}
-`
-
-export const ModalButton = styled.button`
-  ${ModalButtonStyle}
 `

--- a/frontend/src/utils/stats.ts
+++ b/frontend/src/utils/stats.ts
@@ -358,7 +358,7 @@ export const getVaultStats = async (
     id: vaultAddress,
     stakingTokenBalance: stakingTokenBalanceInfo.balance,
     rewardTokenBalance: rewardTokenBalanceInfo.balance,
-    vaultTokenBalances: vaultTokenBalances,
+    vaultTokenBalances,
     currentStake,
   }
 }


### PR DESCRIPTION
## Description

Added a single-transaction feedback modal that keeps the user updated about the state of the transaction.

Added a specific use case modal for unstaking, which keeps the user updated about the states of the 3 transactions that happen when the user unstakes (i.e. unstake, withdraw staking tokens, and withdraw reward tokens)