### PR TITLE
fix conversion from bigint to address

### DIFF
--- a/subgraph/src/vault.ts
+++ b/subgraph/src/vault.ts
@@ -69,8 +69,12 @@ export function handleRageQuit(event: RageQuit): void {
   updateLock(event.address, event.params.delegate, event.params.token, event.block.timestamp)
 }
 
+function bigIntToAddress(value: BigInt): Address {
+  return Address.fromString(value.toHex().slice(2).padStart(40, '0'))
+}
+
 export function handleTransfer(event: Transfer): void {
   let from = new User(event.params.from.toHex())
-  updateVault(Address.fromHexString(event.params.tokenId.toHex()) as Address)
+  updateVault(bigIntToAddress(event.params.tokenId))
   from.save()
 }


### PR DESCRIPTION
## Description

The `Address` API is not smart enough to build an `Address` object when the hex string has length < 40 (e.g. when it has leading zeros). Wrote a function to fix this.