### PR TITLE
fix geyser status in subgraph

### DIFF
--- a/frontend/src/config/geyser.ts
+++ b/frontend/src/config/geyser.ts
@@ -15,7 +15,7 @@ const mockGeyserConfigs: GeyserConfig[] = [
   },
   {
     name: 'Beehive V3 (Uniswap ETH-AMPL)',
-    address: '0x0000000000000000000000000000000000000000',
+    address: '0x4a679253410272dd5232b3ff7cf5dbb88f295319',
     stakingToken: StakingToken.MOCK,
     rewardToken: RewardToken.MOCK,
   },

--- a/frontend/src/context/GeyserContext.tsx
+++ b/frontend/src/context/GeyserContext.tsx
@@ -100,7 +100,7 @@ export const GeyserContextProvider: React.FC = ({ children }) => {
 
   useEffect(() => {
     if (geyserData && geyserData.geysers) {
-      const currentGeysers = [...geyserData.geysers] as Geyser[]
+      const currentGeysers = [...geyserData.geysers].map((geyser) => ({ ...geyser, status: geyser.powerSwitch.status })) as Geyser[]
       const ids = geyserConfigs.map(geyser => geyser.address.toLowerCase())
       currentGeysers.sort((a, b) => ids.indexOf(a.id) - ids.indexOf(b.id))
       setGeysers(currentGeysers)

--- a/frontend/src/queries/geyser.ts
+++ b/frontend/src/queries/geyser.ts
@@ -8,7 +8,6 @@ export const GET_GEYSERS = gql`
       stakingToken
       totalStake
       totalStakeUnits
-      status
       scalingFloor
       scalingCeiling
       scalingTime
@@ -20,6 +19,10 @@ export const GET_GEYSERS = gql`
         rewardAmount
       }
       lastUpdate
+      powerSwitch {
+        id
+        status
+      }
     }
   }
 `

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -4,9 +4,14 @@ enum GeyserStatus {
   Shutdown
 }
 
+type PowerSwitch @entity {
+  id: ID! # ${powerSwitch.address}
+  status: GeyserStatus!
+}
+
 type Geyser @entity {
   id: ID! # ${geyser.address}
-  powerSwitch: Bytes!
+  powerSwitch: PowerSwitch!
   rewardPool: Bytes!
   rewardPoolBalances: [RewardPoolBalance]! @derivedFrom(field: "geyser")
   unlockedReward: BigInt!
@@ -18,7 +23,6 @@ type Geyser @entity {
   totalStake: BigInt!
   totalStakeUnits: BigInt!
   bonusTokens: [Bytes!]!
-  status: GeyserStatus!
   lastUpdate: BigInt!
   rewardSchedules: [RewardSchedule]! @derivedFrom(field: "geyser")
   locks: [Lock]! @derivedFrom(field: "geyser")

--- a/subgraph/src/geyser.ts
+++ b/subgraph/src/geyser.ts
@@ -19,7 +19,7 @@ import { EmergencyShutdown, PowerOff, PowerOn } from '../generated/templates/Pow
 import { ERC20 } from '../generated/templates/GeyserTemplate/ERC20'
 
 // entity imports
-import { ClaimedReward, Geyser, Lock, RewardPoolBalance, RewardSchedule } from '../generated/schema'
+import { ClaimedReward, Geyser, Lock, RewardPoolBalance, RewardSchedule, PowerSwitch } from '../generated/schema'
 
 // template instantiation
 export function handleNewGeyser(event: InstanceAdded): void {
@@ -67,17 +67,19 @@ export function handleGeyserCreated(event: GeyserCreated): void {
   let geyserContract = GeyserContract.bind(event.address)
 
   PowerSwitchTemplate.create(event.params.powerSwitch)
+  let powerSwitch = new PowerSwitch(event.params.powerSwitch.toHex())
+  powerSwitch.status = 'Online'
+  powerSwitch.save()
 
   let geyserData = geyserContract.getGeyserData()
 
-  entity.powerSwitch = event.params.powerSwitch
+  entity.powerSwitch = event.params.powerSwitch.toHex()
   entity.rewardPool = event.params.rewardPool
   entity.stakingToken = geyserData.stakingToken
   entity.rewardToken = geyserData.rewardToken
   entity.scalingFloor = geyserData.rewardScaling.floor
   entity.scalingCeiling = geyserData.rewardScaling.ceiling
   entity.scalingTime = geyserData.rewardScaling.time
-  entity.status = 'Online'
   entity.bonusTokens = []
 
   _updateGeyser(entity, geyserContract, event.block.timestamp)
@@ -163,7 +165,7 @@ export function handleRewardClaimed(event: RewardClaimed): void {
 }
 
 export function handlePowerOn(event: PowerOn): void {
-  let entity = Geyser.load(event.address.toHex())
+  let entity = new PowerSwitch(event.address.toHex())
 
   entity.status = 'Online'
 
@@ -171,7 +173,7 @@ export function handlePowerOn(event: PowerOn): void {
 }
 
 export function handlePowerOff(event: PowerOff): void {
-  let entity = Geyser.load(event.address.toHex())
+  let entity = new PowerSwitch(event.address.toHex())
 
   entity.status = 'Offline'
 
@@ -179,7 +181,7 @@ export function handlePowerOff(event: PowerOff): void {
 }
 
 export function handleEmergencyShutdown(event: EmergencyShutdown): void {
-  let entity = Geyser.load(event.address.toHex())
+  let entity = new PowerSwitch(event.address.toHex())
 
   entity.status = 'Shutdown'
 


### PR DESCRIPTION
## Description

Geyser status is not retrievable from the geyser contract: instead, this is managed by the power switch. A `PowerSwitch` entity has been added to the subgraph to keep track of the geyser status. Updated the frontend query accordingly.